### PR TITLE
17 fix squished ticklines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+examples/* binary
+dist/* binary

--- a/examples/index.js
+++ b/examples/index.js
@@ -26408,14 +26408,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'updateNumX',
 	    value: function updateNumX(event) {
 	      this.setState({
-	        numXTicks: event.target.value
+	        numXTicks: parseInt(event.target.value, 10)
 	      });
 	    }
 	  }, {
 	    key: 'updateNumY',
 	    value: function updateNumY(event) {
 	      this.setState({
-	        numYTicks: event.target.value
+	        numYTicks: parseInt(event.target.value, 10)
 	      });
 	    }
 	  }, {

--- a/src/examples/axis.jsx
+++ b/src/examples/axis.jsx
@@ -14,6 +14,12 @@ type State = {
   points: Object[],
 }
 
+type FormEvent = {
+  target: {
+    value: string
+  }
+}
+
 function randomPoints() {
   return [...Array(10)].map(() => (
     { x: Math.random() * 600, y: Math.random() * 300 })
@@ -49,15 +55,15 @@ class AxisExample extends Component {
     });
   }
 
-  updateNumX(event: Object) {
+  updateNumX(event: FormEvent) {
     this.setState({
-      numXTicks: event.target.value,
+      numXTicks: parseInt(event.target.value, 10),
     });
   }
 
-  updateNumY(event: Object) {
+  updateNumY(event: FormEvent) {
     this.setState({
-      numYTicks: event.target.value,
+      numYTicks: parseInt(event.target.value, 10),
     });
   }
 


### PR DESCRIPTION
Previously, the axis example, when updating the numTicks for either X or Y axis,
would squish them towards the origin.

This fixes that behavior.

Additionally, we mark the compiled JS files as Binary files for git to simplify reading diffs