### PR TITLE
Add theme editor to examples page

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65,43 +65,43 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _jubilationAnimation2 = _interopRequireDefault(_jubilationAnimation);
 
-	var _jubilationChart = __webpack_require__(35);
+	var _jubilationChart = __webpack_require__(33);
 
 	var _jubilationChart2 = _interopRequireDefault(_jubilationChart);
 
-	var _jubilationContainer = __webpack_require__(48);
+	var _jubilationContainer = __webpack_require__(46);
 
 	var _jubilationContainer2 = _interopRequireDefault(_jubilationContainer);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _jubilationPoint = __webpack_require__(52);
+	var _jubilationPoint = __webpack_require__(50);
 
 	var _jubilationPoint2 = _interopRequireDefault(_jubilationPoint);
 
-	var _jubilationProvider = __webpack_require__(36);
+	var _jubilationProvider = __webpack_require__(34);
 
 	var _jubilationProvider2 = _interopRequireDefault(_jubilationProvider);
 
-	var _jubilationScatter = __webpack_require__(53);
+	var _jubilationScatter = __webpack_require__(51);
 
 	var _jubilationScatter2 = _interopRequireDefault(_jubilationScatter);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _jubilationHorizontalBar = __webpack_require__(55);
+	var _jubilationHorizontalBar = __webpack_require__(53);
 
 	var _jubilationHorizontalBar2 = _interopRequireDefault(_jubilationHorizontalBar);
 
-	var _jubilationVerticalBar = __webpack_require__(59);
+	var _jubilationVerticalBar = __webpack_require__(57);
 
 	var _jubilationVerticalBar2 = _interopRequireDefault(_jubilationVerticalBar);
 
-	var _jubilationAxis = __webpack_require__(60);
+	var _jubilationAxis = __webpack_require__(58);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -134,13 +134,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _d3Ease = __webpack_require__(31);
+	var _d3Ease = __webpack_require__(29);
 
 	var d3Ease = _interopRequireWildcard(_d3Ease);
 
-	var _d3Interpolate = __webpack_require__(32);
+	var _d3Interpolate = __webpack_require__(30);
 
-	var _d3Timer = __webpack_require__(34);
+	var _d3Timer = __webpack_require__(32);
 
 	function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
@@ -294,7 +294,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule React
 	 */
 
 	'use strict';
@@ -302,15 +301,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _assign = __webpack_require__(4);
 
 	var ReactChildren = __webpack_require__(5);
-	var ReactComponent = __webpack_require__(17);
-	var ReactPureComponent = __webpack_require__(20);
-	var ReactClass = __webpack_require__(21);
-	var ReactDOMFactories = __webpack_require__(26);
+	var ReactComponent = __webpack_require__(18);
+	var ReactPureComponent = __webpack_require__(21);
+	var ReactClass = __webpack_require__(22);
+	var ReactDOMFactories = __webpack_require__(24);
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypes = __webpack_require__(27);
-	var ReactVersion = __webpack_require__(29);
+	var ReactPropTypes = __webpack_require__(25);
+	var ReactVersion = __webpack_require__(27);
 
-	var onlyChild = __webpack_require__(30);
+	var onlyChild = __webpack_require__(28);
 	var warning = __webpack_require__(11);
 
 	var createElement = ReactElement.createElement;
@@ -476,7 +475,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactChildren
 	 */
 
 	'use strict';
@@ -485,7 +483,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var ReactElement = __webpack_require__(9);
 
 	var emptyFunction = __webpack_require__(12);
-	var traverseAllChildren = __webpack_require__(14);
+	var traverseAllChildren = __webpack_require__(15);
 
 	var twoArgumentPooler = PooledClass.twoArgumentPooler;
 	var fourArgumentPooler = PooledClass.fourArgumentPooler;
@@ -516,8 +514,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	PooledClass.addPoolingTo(ForEachBookKeeping, twoArgumentPooler);
 
 	function forEachSingleChild(bookKeeping, child, name) {
-	  var func = bookKeeping.func;
-	  var context = bookKeeping.context;
+	  var func = bookKeeping.func,
+	      context = bookKeeping.context;
 
 	  func.call(context, child, bookKeeping.count++);
 	}
@@ -569,10 +567,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	PooledClass.addPoolingTo(MapBookKeeping, fourArgumentPooler);
 
 	function mapSingleChildIntoContext(bookKeeping, child, childKey) {
-	  var result = bookKeeping.result;
-	  var keyPrefix = bookKeeping.keyPrefix;
-	  var func = bookKeeping.func;
-	  var context = bookKeeping.context;
+	  var result = bookKeeping.result,
+	      keyPrefix = bookKeeping.keyPrefix,
+	      func = bookKeeping.func,
+	      context = bookKeeping.context;
 
 	  var mappedChild = func.call(context, child, bookKeeping.count++);
 	  if (Array.isArray(mappedChild)) {
@@ -671,7 +669,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule PooledClass
+	 * 
 	 */
 
 	'use strict';
@@ -764,6 +762,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param {Function} pooler Customizable pooler.
 	 */
 	var addPoolingTo = function addPoolingTo(CopyConstructor, pooler) {
+	  // Casting as any so that flow ignores the actual implementation and trusts
+	  // it to match the type we declared
 	  var NewKlass = CopyConstructor;
 	  NewKlass.instancePool = [];
 	  NewKlass.getPooled = pooler || DEFAULT_POOLER;
@@ -797,7 +797,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule reactProdInvariant
 	 * 
 	 */
 	'use strict';
@@ -895,7 +894,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactElement
 	 */
 
 	'use strict';
@@ -910,9 +908,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var canDefineProperty = __webpack_require__(13);
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-	// The Symbol used to tag the ReactElement type. If there is no native Symbol
-	// nor polyfill, then a plain number is used for performance.
-	var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+	var REACT_ELEMENT_TYPE = __webpack_require__(14);
 
 	var RESERVED_PROPS = {
 	  key: true,
@@ -1016,7 +1012,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // This can be replaced with a WeakMap once they are implemented in
 	    // commonly used development environments.
 	    element._store = {};
-	    var shadowChildren = Array.isArray(props.children) ? props.children.slice(0) : props.children;
 
 	    // To make comparing ReactElements easier for testing purposes, we make
 	    // the validation flag non-enumerable (where possible, which should
@@ -1036,12 +1031,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	        writable: false,
 	        value: self
 	      });
-	      Object.defineProperty(element, '_shadowChildren', {
-	        configurable: false,
-	        enumerable: false,
-	        writable: false,
-	        value: shadowChildren
-	      });
 	      // Two elements created in two different places should be considered
 	      // equal for testing purposes and therefore we hide it from enumeration.
 	      Object.defineProperty(element, '_source', {
@@ -1053,7 +1042,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    } else {
 	      element._store.validated = false;
 	      element._self = self;
-	      element._shadowChildren = shadowChildren;
 	      element._source = source;
 	    }
 	    if (Object.freeze) {
@@ -1107,6 +1095,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var childArray = Array(childrenLength);
 	    for (var i = 0; i < childrenLength; i++) {
 	      childArray[i] = arguments[i + 2];
+	    }
+	    if (false) {
+	      if (Object.freeze) {
+	        Object.freeze(childArray);
+	      }
 	    }
 	    props.children = childArray;
 	  }
@@ -1234,8 +1227,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return (typeof object === 'undefined' ? 'undefined' : _typeof(object)) === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
 	};
 
-	ReactElement.REACT_ELEMENT_TYPE = REACT_ELEMENT_TYPE;
-
 	module.exports = ReactElement;
 
 /***/ },
@@ -1250,7 +1241,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactCurrentOwner
+	 * 
 	 */
 
 	'use strict';
@@ -1400,7 +1391,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule canDefineProperty
+	 * 
 	 */
 
 	'use strict';
@@ -1408,6 +1399,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var canDefineProperty = false;
 	if (false) {
 	  try {
+	    // $FlowFixMe https://github.com/facebook/flow/issues/285
 	    Object.defineProperty({}, 'x', { get: function get() {} });
 	    canDefineProperty = true;
 	  } catch (x) {
@@ -1419,6 +1411,30 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 /* 14 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2014-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	// The Symbol used to tag the ReactElement type. If there is no native Symbol
+	// nor polyfill, then a plain number is used for performance.
+
+	var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+	module.exports = REACT_ELEMENT_TYPE;
+
+/***/ },
+/* 15 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1429,7 +1445,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule traverseAllChildren
 	 */
 
 	'use strict';
@@ -1439,15 +1454,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _prodInvariant = __webpack_require__(7);
 
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactElement = __webpack_require__(9);
+	var REACT_ELEMENT_TYPE = __webpack_require__(14);
 
-	var getIteratorFn = __webpack_require__(15);
+	var getIteratorFn = __webpack_require__(16);
 	var invariant = __webpack_require__(8);
-	var KeyEscapeUtils = __webpack_require__(16);
+	var KeyEscapeUtils = __webpack_require__(17);
 	var warning = __webpack_require__(11);
 
 	var SEPARATOR = '.';
 	var SUBSEPARATOR = ':';
+
+	/**
+	 * This is inlined from ReactElement since this file is shared between
+	 * isomorphic and renderers. We could extract this to a
+	 *
+	 */
 
 	/**
 	 * TODO: Test that a single child and an array with one item have the same key
@@ -1490,7 +1511,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    children = null;
 	  }
 
-	  if (children === null || type === 'string' || type === 'number' || ReactElement.isValidElement(children)) {
+	  if (children === null || type === 'string' || type === 'number' ||
+	  // The following is inlined from ReactElement. This means we can optimize
+	  // some checks. React Fiber also inlines this logic for similar purposes.
+	  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
 	    callback(traverseContext, children,
 	    // If it's the only child, treat the name as if it was wrapped in an array
 	    // so that it's consistent if the number of children grows.
@@ -1592,7 +1616,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = traverseAllChildren;
 
 /***/ },
-/* 15 */
+/* 16 */
 /***/ function(module, exports) {
 
 	/**
@@ -1603,7 +1627,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getIteratorFn
 	 * 
 	 */
 
@@ -1638,7 +1661,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getIteratorFn;
 
 /***/ },
-/* 16 */
+/* 17 */
 /***/ function(module, exports) {
 
 	/**
@@ -1649,7 +1672,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule KeyEscapeUtils
 	 * 
 	 */
 
@@ -1702,7 +1724,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = KeyEscapeUtils;
 
 /***/ },
-/* 17 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1713,7 +1735,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactComponent
 	 */
 
 	'use strict';
@@ -1722,10 +1743,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _prodInvariant = __webpack_require__(7);
 
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
 	var canDefineProperty = __webpack_require__(13);
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
 
@@ -1827,7 +1848,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactComponent;
 
 /***/ },
-/* 18 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1838,7 +1859,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactNoopUpdateQueue
 	 */
 
 	'use strict';
@@ -1928,7 +1948,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactNoopUpdateQueue;
 
 /***/ },
-/* 19 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1952,7 +1972,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = emptyObject;
 
 /***/ },
-/* 20 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1963,17 +1983,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPureComponent
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var ReactComponent = __webpack_require__(17);
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactComponent = __webpack_require__(18);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 
 	/**
 	 * Base class helpers for the updating state of a component.
@@ -1999,7 +2018,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPureComponent;
 
 /***/ },
-/* 21 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -2010,7 +2029,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactClass
 	 */
 
 	'use strict';
@@ -2020,44 +2038,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _prodInvariant = __webpack_require__(7),
 	    _assign = __webpack_require__(4);
 
-	var ReactComponent = __webpack_require__(17);
+	var ReactComponent = __webpack_require__(18);
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypeLocations = __webpack_require__(22);
-	var ReactPropTypeLocationNames = __webpack_require__(24);
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactPropTypeLocationNames = __webpack_require__(23);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 	var invariant = __webpack_require__(8);
-	var keyMirror = __webpack_require__(23);
-	var keyOf = __webpack_require__(25);
 	var warning = __webpack_require__(11);
 
-	var MIXINS_KEY = keyOf({ mixins: null });
+	var MIXINS_KEY = 'mixins';
+
+	// Helper function to allow the creation of anonymous functions which do not
+	// have .name set to the name of the variable being assigned to.
+	function identity(fn) {
+	  return fn;
+	}
 
 	/**
 	 * Policies that describe methods in `ReactClassInterface`.
 	 */
-	var SpecPolicy = keyMirror({
-	  /**
-	   * These methods may be defined only once by the class specification or mixin.
-	   */
-	  DEFINE_ONCE: null,
-	  /**
-	   * These methods may be defined by both the class specification and mixins.
-	   * Subsequent definitions will be chained. These methods must return void.
-	   */
-	  DEFINE_MANY: null,
-	  /**
-	   * These methods are overriding the base class.
-	   */
-	  OVERRIDE_BASE: null,
-	  /**
-	   * These methods are similar to DEFINE_MANY, except we assume they return
-	   * objects. We try to merge the keys of the return values of all the mixed in
-	   * functions. If there is a key conflict we throw.
-	   */
-	  DEFINE_MANY_MERGED: null
-	});
 
 	var injectedMixins = [];
 
@@ -2091,7 +2091,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {array}
 	   * @optional
 	   */
-	  mixins: SpecPolicy.DEFINE_MANY,
+	  mixins: 'DEFINE_MANY',
 
 	  /**
 	   * An object containing properties and methods that should be defined on
@@ -2100,7 +2100,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  statics: SpecPolicy.DEFINE_MANY,
+	  statics: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of prop types for this component.
@@ -2108,7 +2108,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  propTypes: SpecPolicy.DEFINE_MANY,
+	  propTypes: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of context types for this component.
@@ -2116,7 +2116,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  contextTypes: SpecPolicy.DEFINE_MANY,
+	  contextTypes: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of context types this component sets for its children.
@@ -2124,7 +2124,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  childContextTypes: SpecPolicy.DEFINE_MANY,
+	  childContextTypes: 'DEFINE_MANY',
 
 	  // ==== Definition methods ====
 
@@ -2138,7 +2138,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {object}
 	   * @optional
 	   */
-	  getDefaultProps: SpecPolicy.DEFINE_MANY_MERGED,
+	  getDefaultProps: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * Invoked once before the component is mounted. The return value will be used
@@ -2154,13 +2154,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {object}
 	   * @optional
 	   */
-	  getInitialState: SpecPolicy.DEFINE_MANY_MERGED,
+	  getInitialState: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * @return {object}
 	   * @optional
 	   */
-	  getChildContext: SpecPolicy.DEFINE_MANY_MERGED,
+	  getChildContext: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * Uses props from `this.props` and state from `this.state` to render the
@@ -2178,7 +2178,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @nosideeffects
 	   * @required
 	   */
-	  render: SpecPolicy.DEFINE_ONCE,
+	  render: 'DEFINE_ONCE',
 
 	  // ==== Delegate methods ====
 
@@ -2189,7 +2189,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @optional
 	   */
-	  componentWillMount: SpecPolicy.DEFINE_MANY,
+	  componentWillMount: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component has been mounted and has a DOM representation.
@@ -2201,7 +2201,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {DOMElement} rootNode DOM element representing the component.
 	   * @optional
 	   */
-	  componentDidMount: SpecPolicy.DEFINE_MANY,
+	  componentDidMount: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked before the component receives new props.
@@ -2222,7 +2222,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {object} nextProps
 	   * @optional
 	   */
-	  componentWillReceiveProps: SpecPolicy.DEFINE_MANY,
+	  componentWillReceiveProps: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked while deciding if the component should be updated as a result of
@@ -2244,7 +2244,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {boolean} True if the component should update.
 	   * @optional
 	   */
-	  shouldComponentUpdate: SpecPolicy.DEFINE_ONCE,
+	  shouldComponentUpdate: 'DEFINE_ONCE',
 
 	  /**
 	   * Invoked when the component is about to update due to a transition from
@@ -2261,7 +2261,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {ReactReconcileTransaction} transaction
 	   * @optional
 	   */
-	  componentWillUpdate: SpecPolicy.DEFINE_MANY,
+	  componentWillUpdate: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component's DOM representation has been updated.
@@ -2275,7 +2275,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {DOMElement} rootNode DOM element representing the component.
 	   * @optional
 	   */
-	  componentDidUpdate: SpecPolicy.DEFINE_MANY,
+	  componentDidUpdate: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component is about to be removed from its parent and have
@@ -2288,7 +2288,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @optional
 	   */
-	  componentWillUnmount: SpecPolicy.DEFINE_MANY,
+	  componentWillUnmount: 'DEFINE_MANY',
 
 	  // ==== Advanced methods ====
 
@@ -2302,7 +2302,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @internal
 	   * @overridable
 	   */
-	  updateComponent: SpecPolicy.OVERRIDE_BASE
+	  updateComponent: 'OVERRIDE_BASE'
 
 	};
 
@@ -2328,13 +2328,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  childContextTypes: function childContextTypes(Constructor, _childContextTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _childContextTypes, ReactPropTypeLocations.childContext);
+	      validateTypeDef(Constructor, _childContextTypes, 'childContext');
 	    }
 	    Constructor.childContextTypes = _assign({}, Constructor.childContextTypes, _childContextTypes);
 	  },
 	  contextTypes: function contextTypes(Constructor, _contextTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _contextTypes, ReactPropTypeLocations.context);
+	      validateTypeDef(Constructor, _contextTypes, 'context');
 	    }
 	    Constructor.contextTypes = _assign({}, Constructor.contextTypes, _contextTypes);
 	  },
@@ -2351,7 +2351,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  propTypes: function propTypes(Constructor, _propTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _propTypes, ReactPropTypeLocations.prop);
+	      validateTypeDef(Constructor, _propTypes, 'prop');
 	    }
 	    Constructor.propTypes = _assign({}, Constructor.propTypes, _propTypes);
 	  },
@@ -2360,7 +2360,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  autobind: function autobind() {} };
 
-	// noop
 	function validateTypeDef(Constructor, typeDef, location) {
 	  for (var propName in typeDef) {
 	    if (typeDef.hasOwnProperty(propName)) {
@@ -2376,12 +2375,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Disallow overriding of base class methods unless explicitly allowed.
 	  if (ReactClassMixin.hasOwnProperty(name)) {
-	    !(specPolicy === SpecPolicy.OVERRIDE_BASE) ?  false ? invariant(false, 'ReactClassInterface: You are attempting to override `%s` from your class specification. Ensure that your method names do not overlap with React methods.', name) : _prodInvariant('73', name) : void 0;
+	    !(specPolicy === 'OVERRIDE_BASE') ?  false ? invariant(false, 'ReactClassInterface: You are attempting to override `%s` from your class specification. Ensure that your method names do not overlap with React methods.', name) : _prodInvariant('73', name) : void 0;
 	  }
 
 	  // Disallow defining methods more than once unless explicitly allowed.
 	  if (isAlreadyDefined) {
-	    !(specPolicy === SpecPolicy.DEFINE_MANY || specPolicy === SpecPolicy.DEFINE_MANY_MERGED) ?  false ? invariant(false, 'ReactClassInterface: You are attempting to define `%s` on your component more than once. This conflict may be due to a mixin.', name) : _prodInvariant('74', name) : void 0;
+	    !(specPolicy === 'DEFINE_MANY' || specPolicy === 'DEFINE_MANY_MERGED') ?  false ? invariant(false, 'ReactClassInterface: You are attempting to define `%s` on your component more than once. This conflict may be due to a mixin.', name) : _prodInvariant('74', name) : void 0;
 	  }
 	}
 
@@ -2447,13 +2446,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	          var specPolicy = ReactClassInterface[name];
 
 	          // These cases should already be caught by validateMethodOverride.
-	          !(isReactClassMethod && (specPolicy === SpecPolicy.DEFINE_MANY_MERGED || specPolicy === SpecPolicy.DEFINE_MANY)) ?  false ? invariant(false, 'ReactClass: Unexpected spec policy %s for key %s when mixing in component specs.', specPolicy, name) : _prodInvariant('77', specPolicy, name) : void 0;
+	          !(isReactClassMethod && (specPolicy === 'DEFINE_MANY_MERGED' || specPolicy === 'DEFINE_MANY')) ?  false ? invariant(false, 'ReactClass: Unexpected spec policy %s for key %s when mixing in component specs.', specPolicy, name) : _prodInvariant('77', specPolicy, name) : void 0;
 
 	          // For methods which are defined more than once, call the existing
 	          // methods before calling the new property, merging if appropriate.
-	          if (specPolicy === SpecPolicy.DEFINE_MANY_MERGED) {
+	          if (specPolicy === 'DEFINE_MANY_MERGED') {
 	            proto[name] = createMergedResultFunction(proto[name], property);
-	          } else if (specPolicy === SpecPolicy.DEFINE_MANY) {
+	          } else if (specPolicy === 'DEFINE_MANY') {
 	            proto[name] = createChainedFunction(proto[name], property);
 	          }
 	        } else {
@@ -2648,7 +2647,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @public
 	   */
 	  createClass: function createClass(spec) {
-	    var Constructor = function Constructor(props, context, updater) {
+	    // To keep our warnings more understandable, we'll use a little hack here to
+	    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+	    // unnecessarily identify a class without displayName as 'Constructor'.
+	    var Constructor = identity(function (props, context, updater) {
 	      // This constructor gets overridden by mocks. The argument is used
 	      // by mocks to assert on what gets mounted.
 
@@ -2683,7 +2685,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      !((typeof initialState === 'undefined' ? 'undefined' : _typeof(initialState)) === 'object' && !Array.isArray(initialState)) ?  false ? invariant(false, '%s.getInitialState(): must return an object or null', Constructor.displayName || 'ReactCompositeComponent') : _prodInvariant('82', Constructor.displayName || 'ReactCompositeComponent') : void 0;
 
 	      this.state = initialState;
-	    };
+	    });
 	    Constructor.prototype = new ReactClassComponent();
 	    Constructor.prototype.constructor = Constructor;
 	    Constructor.prototype.__reactAutoBindPairs = [];
@@ -2738,89 +2740,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactClass;
 
 /***/ },
-/* 22 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule ReactPropTypeLocations
-	 */
-
-	'use strict';
-
-	var keyMirror = __webpack_require__(23);
-
-	var ReactPropTypeLocations = keyMirror({
-	  prop: null,
-	  context: null,
-	  childContext: null
-	});
-
-	module.exports = ReactPropTypeLocations;
-
-/***/ },
 /* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @typechecks static-only
-	 */
-
-	'use strict';
-
-	var invariant = __webpack_require__(8);
-
-	/**
-	 * Constructs an enumeration with keys equal to their value.
-	 *
-	 * For example:
-	 *
-	 *   var COLORS = keyMirror({blue: null, red: null});
-	 *   var myColor = COLORS.blue;
-	 *   var isColorValid = !!COLORS[myColor];
-	 *
-	 * The last line could not be performed if the values of the generated enum were
-	 * not equal to their keys.
-	 *
-	 *   Input:  {key1: val1, key2: val2}
-	 *   Output: {key1: key1, key2: key2}
-	 *
-	 * @param {object} obj
-	 * @return {object}
-	 */
-	var keyMirror = function keyMirror(obj) {
-	  var ret = {};
-	  var key;
-	  !(obj instanceof Object && !Array.isArray(obj)) ?  false ? invariant(false, 'keyMirror(...): Argument must be an object.') : invariant(false) : void 0;
-	  for (key in obj) {
-	    if (!obj.hasOwnProperty(key)) {
-	      continue;
-	    }
-	    ret[key] = key;
-	  }
-	  return ret;
-	};
-
-	module.exports = keyMirror;
-
-/***/ },
-/* 24 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
 	 * Copyright 2013-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
@@ -2828,7 +2751,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypeLocationNames
+	 * 
 	 */
 
 	'use strict';
@@ -2846,47 +2769,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypeLocationNames;
 
 /***/ },
-/* 25 */
-/***/ function(module, exports) {
-
-	"use strict";
-
-	/**
-	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	/**
-	 * Allows extraction of a minified key. Let's the build system minify keys
-	 * without losing the ability to dynamically use key strings as values
-	 * themselves. Pass in an object with a single key/val pair and it will return
-	 * you the string key of that single record. Suppose you want to grab the
-	 * value for a key 'className' inside of an object. Key/val minification may
-	 * have aliased that key to be 'xa12'. keyOf({className: null}) will return
-	 * 'xa12' in that case. Resolve keys you want to use once at startup time, then
-	 * reuse those resolutions.
-	 */
-
-	var keyOf = function keyOf(oneKeyObj) {
-	  var key;
-	  for (key in oneKeyObj) {
-	    if (!oneKeyObj.hasOwnProperty(key)) {
-	      continue;
-	    }
-	    return key;
-	  }
-	  return null;
-	};
-
-	module.exports = keyOf;
-
-/***/ },
-/* 26 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -2897,7 +2780,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMFactories
 	 */
 
 	'use strict';
@@ -3061,7 +2943,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMFactories;
 
 /***/ },
-/* 27 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -3072,7 +2954,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypes
 	 */
 
 	'use strict';
@@ -3080,11 +2961,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypeLocationNames = __webpack_require__(24);
-	var ReactPropTypesSecret = __webpack_require__(28);
+	var ReactPropTypeLocationNames = __webpack_require__(23);
+	var ReactPropTypesSecret = __webpack_require__(26);
 
 	var emptyFunction = __webpack_require__(12);
-	var getIteratorFn = __webpack_require__(15);
+	var getIteratorFn = __webpack_require__(16);
 	var warning = __webpack_require__(11);
 
 	/**
@@ -3199,7 +3080,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (secret !== ReactPropTypesSecret && typeof console !== 'undefined') {
 	        var cacheKey = componentName + ':' + propName;
 	        if (!manualPropTypeCallCache[cacheKey]) {
-	          process.env.NODE_ENV !== 'production' ? warning(false, 'You are manually calling a React.PropTypes validation ' + 'function for the `%s` prop on `%s`. This is deprecated ' + 'and will not work in the next major version. You may be ' + 'seeing this warning due to a third-party PropTypes library. ' + 'See https://fb.me/react-warning-dont-call-proptypes for details.', propFullName, componentName) : void 0;
+	          process.env.NODE_ENV !== 'production' ? warning(false, 'You are manually calling a React.PropTypes validation ' + 'function for the `%s` prop on `%s`. This is deprecated ' + 'and will not work in production with the next major version. ' + 'You may be seeing this warning due to a third-party PropTypes ' + 'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.', propFullName, componentName) : void 0;
 	          manualPropTypeCallCache[cacheKey] = true;
 	        }
 	      }
@@ -3207,7 +3088,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (props[propName] == null) {
 	      var locationName = ReactPropTypeLocationNames[location];
 	      if (isRequired) {
-	        return new PropTypeError('Required ' + locationName + ' `' + propFullName + '` was not specified in ' + ('`' + componentName + '`.'));
+	        if (props[propName] === null) {
+	          return new PropTypeError('The ' + locationName + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+	        }
+	        return new PropTypeError('The ' + locationName + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
 	      }
 	      return null;
 	    } else {
@@ -3499,7 +3383,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypes;
 
 /***/ },
-/* 28 */
+/* 26 */
 /***/ function(module, exports) {
 
 	/**
@@ -3510,7 +3394,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypesSecret
+	 * 
 	 */
 
 	'use strict';
@@ -3520,7 +3404,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypesSecret;
 
 /***/ },
-/* 29 */
+/* 27 */
 /***/ function(module, exports) {
 
 	/**
@@ -3531,15 +3415,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactVersion
 	 */
 
 	'use strict';
 
-	module.exports = '15.3.2';
+	module.exports = '15.4.1';
 
 /***/ },
-/* 30 */
+/* 28 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -3550,7 +3433,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule onlyChild
 	 */
 	'use strict';
 
@@ -3582,14 +3464,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = onlyChild;
 
 /***/ },
-/* 31 */
+/* 29 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-ease/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-ease/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
@@ -3663,6 +3545,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var pi = Math.PI;
 	  var halfPi = pi / 2;
+
 	  function sinIn(t) {
 	    return 1 - Math.cos(t * halfPi);
 	  }
@@ -3709,6 +3592,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var b8 = 21 / 22;
 	  var b9 = 63 / 64;
 	  var b0 = 1 / b1 / b1;
+
 	  function bounceIn(t) {
 	    return 1 - bounceOut(1 - t);
 	  }
@@ -3762,6 +3646,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var tau = 2 * Math.PI;
 	  var amplitude = 1;
 	  var period = 0.3;
+
 	  var elasticIn = function custom(a, p) {
 	    var s = Math.asin(1 / (a = Math.max(1, a))) * (p /= tau);
 
@@ -3855,16 +3740,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 32 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-interpolate/ Version 1.1.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-interpolate/ Version 1.1.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(33)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(31)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
 	})(undefined, function (exports, d3Color) {
 	  'use strict';
 
@@ -3874,7 +3759,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return ((1 - 3 * t1 + 3 * t2 - t3) * v0 + (4 - 6 * t2 + 3 * t3) * v1 + (1 + 3 * t1 + 3 * t2 - 3 * t3) * v2 + t3 * v3) / 6;
 	  }
 
-	  function basis$1(values) {
+	  var basis$1 = function basis$1(values) {
 	    var n = values.length - 1;
 	    return function (t) {
 	      var i = t <= 0 ? t = 0 : t >= 1 ? (t = 1, n - 1) : Math.floor(t * n),
@@ -3884,9 +3769,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	          v3 = i < n - 1 ? values[i + 2] : 2 * v2 - v1;
 	      return basis((t - i / n) * n, v0, v1, v2, v3);
 	    };
-	  }
+	  };
 
-	  function basisClosed(values) {
+	  var basisClosed = function basisClosed(values) {
 	    var n = values.length;
 	    return function (t) {
 	      var i = Math.floor(((t %= 1) < 0 ? ++t : t) * n),
@@ -3896,13 +3781,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	          v3 = values[(i + 2) % n];
 	      return basis((t - i / n) * n, v0, v1, v2, v3);
 	    };
-	  }
+	  };
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
 	  function linear(a, d) {
 	    return function (t) {
@@ -3933,13 +3818,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  var rgb$1 = function rgbGamma(y) {
-	    var color = gamma(y);
+	    var color$$1 = gamma(y);
 
-	    function rgb(start, end) {
-	      var r = color((start = d3Color.rgb(start)).r, (end = d3Color.rgb(end)).r),
-	          g = color(start.g, end.g),
-	          b = color(start.b, end.b),
-	          opacity = color(start.opacity, end.opacity);
+	    function rgb$$1(start, end) {
+	      var r = color$$1((start = d3Color.rgb(start)).r, (end = d3Color.rgb(end)).r),
+	          g = color$$1(start.g, end.g),
+	          b = color$$1(start.b, end.b),
+	          opacity = color$$1(start.opacity, end.opacity);
 	      return function (t) {
 	        start.r = r(t);
 	        start.g = g(t);
@@ -3949,9 +3834,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      };
 	    }
 
-	    rgb.gamma = rgbGamma;
+	    rgb$$1.gamma = rgbGamma;
 
-	    return rgb;
+	    return rgb$$1;
 	  }(1);
 
 	  function rgbSpline(spline) {
@@ -3961,22 +3846,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	          g = new Array(n),
 	          b = new Array(n),
 	          i,
-	          color;
+	          color$$1;
 	      for (i = 0; i < n; ++i) {
-	        color = d3Color.rgb(colors[i]);
-	        r[i] = color.r || 0;
-	        g[i] = color.g || 0;
-	        b[i] = color.b || 0;
+	        color$$1 = d3Color.rgb(colors[i]);
+	        r[i] = color$$1.r || 0;
+	        g[i] = color$$1.g || 0;
+	        b[i] = color$$1.b || 0;
 	      }
 	      r = spline(r);
 	      g = spline(g);
 	      b = spline(b);
-	      color.opacity = 1;
+	      color$$1.opacity = 1;
 	      return function (t) {
-	        color.r = r(t);
-	        color.g = g(t);
-	        color.b = b(t);
-	        return color + "";
+	        color$$1.r = r(t);
+	        color$$1.g = g(t);
+	        color$$1.b = b(t);
+	        return color$$1 + "";
 	      };
 	    };
 	  }
@@ -3984,7 +3869,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var rgbBasis = rgbSpline(basis$1);
 	  var rgbBasisClosed = rgbSpline(basisClosed);
 
-	  function array(a, b) {
+	  var array = function array(a, b) {
 	    var nb = b ? b.length : 0,
 	        na = a ? Math.min(nb, a.length) : 0,
 	        x = new Array(nb),
@@ -4000,22 +3885,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	        c[i] = x[i](t);
 	      }return c;
 	    };
-	  }
+	  };
 
-	  function date(a, b) {
+	  var date = function date(a, b) {
 	    var d = new Date();
 	    return a = +a, b -= a, function (t) {
 	      return d.setTime(a + b * t), d;
 	    };
-	  }
+	  };
 
-	  function number(a, b) {
+	  var number = function number(a, b) {
 	    return a = +a, b -= a, function (t) {
 	      return a + b * t;
 	    };
-	  }
+	  };
 
-	  function object(a, b) {
+	  var object = function object(a, b) {
 	    var i = {},
 	        c = {},
 	        k;
@@ -4036,10 +3921,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	        c[k] = i[k](t);
 	      }return c;
 	    };
-	  }
+	  };
 
 	  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g;
 	  var reB = new RegExp(reA.source, "g");
+
 	  function zero(b) {
 	    return function () {
 	      return b;
@@ -4052,7 +3938,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function string(a, b) {
+	  var string = function string(a, b) {
 	    var bi = reA.lastIndex = reB.lastIndex = 0,
 	        // scan index for next number in b
 	    am,
@@ -4104,19 +3990,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	        s[(o = q[i]).i] = o.x(t);
 	      }return s.join("");
 	    });
-	  }
+	  };
 
-	  function value(a, b) {
+	  var value = function value(a, b) {
 	    var t = typeof b === 'undefined' ? 'undefined' : _typeof(b),
 	        c;
 	    return b == null || t === "boolean" ? constant(b) : (t === "number" ? number : t === "string" ? (c = d3Color.color(b)) ? (b = c, rgb$1) : string : b instanceof d3Color.color ? rgb$1 : b instanceof Date ? date : Array.isArray(b) ? array : isNaN(b) ? object : number)(a, b);
-	  }
+	  };
 
-	  function round(a, b) {
+	  var round = function round(a, b) {
 	    return a = +a, b -= a, function (t) {
 	      return Math.round(a + b * t);
 	    };
-	  }
+	  };
 
 	  var degrees = 180 / Math.PI;
 
@@ -4129,7 +4015,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    scaleY: 1
 	  };
 
-	  function decompose(a, b, c, d, e, f) {
+	  var decompose = function decompose(a, b, c, d, e, f) {
 	    var scaleX, scaleY, skewX;
 	    if (scaleX = Math.sqrt(a * a + b * b)) a /= scaleX, b /= scaleX;
 	    if (skewX = a * c + b * d) c -= a * skewX, d -= b * skewX;
@@ -4143,12 +4029,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scaleX: scaleX,
 	      scaleY: scaleY
 	    };
-	  }
+	  };
 
 	  var cssNode;
 	  var cssRoot;
 	  var cssView;
 	  var svgNode;
+
 	  function parseCss(value) {
 	    if (value === "none") return identity;
 	    if (!cssNode) cssNode = document.createElement("DIV"), cssRoot = document.documentElement, cssView = document.defaultView;
@@ -4237,6 +4124,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var rho2 = 2;
 	  var rho4 = 4;
 	  var epsilon2 = 1e-12;
+
 	  function cosh(x) {
 	    return ((x = Math.exp(x)) + 1 / x) / 2;
 	  }
@@ -4251,7 +4139,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // p0 = [ux0, uy0, w0]
 	  // p1 = [ux1, uy1, w1]
-	  function zoom(p0, p1) {
+	  var zoom = function zoom(p0, p1) {
 	    var ux0 = p0[0],
 	        uy0 = p0[1],
 	        w0 = p0[2],
@@ -4291,11 +4179,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    i.duration = S * 1000;
 
 	    return i;
-	  }
+	  };
 
-	  function hsl$1(hue) {
+	  function hsl$1(hue$$1) {
 	    return function (start, end) {
-	      var h = hue((start = d3Color.hsl(start)).h, (end = d3Color.hsl(end)).h),
+	      var h = hue$$1((start = d3Color.hsl(start)).h, (end = d3Color.hsl(end)).h),
 	          s = nogamma(start.s, end.s),
 	          l = nogamma(start.l, end.l),
 	          opacity = nogamma(start.opacity, end.opacity);
@@ -4326,9 +4214,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function hcl$1(hue) {
+	  function hcl$1(hue$$1) {
 	    return function (start, end) {
-	      var h = hue((start = d3Color.hcl(start)).h, (end = d3Color.hcl(end)).h),
+	      var h = hue$$1((start = d3Color.hcl(start)).h, (end = d3Color.hcl(end)).h),
 	          c = nogamma(start.c, end.c),
 	          l = nogamma(start.l, end.l),
 	          opacity = nogamma(start.opacity, end.opacity);
@@ -4345,12 +4233,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var hcl$2 = hcl$1(hue);
 	  var hclLong = hcl$1(nogamma);
 
-	  function cubehelix$1(hue) {
+	  function cubehelix$1(hue$$1) {
 	    return function cubehelixGamma(y) {
 	      y = +y;
 
-	      function cubehelix(start, end) {
-	        var h = hue((start = d3Color.cubehelix(start)).h, (end = d3Color.cubehelix(end)).h),
+	      function cubehelix$$1(start, end) {
+	        var h = hue$$1((start = d3Color.cubehelix(start)).h, (end = d3Color.cubehelix(end)).h),
 	            s = nogamma(start.s, end.s),
 	            l = nogamma(start.l, end.l),
 	            opacity = nogamma(start.opacity, end.opacity);
@@ -4363,21 +4251,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	        };
 	      }
 
-	      cubehelix.gamma = cubehelixGamma;
+	      cubehelix$$1.gamma = cubehelixGamma;
 
-	      return cubehelix;
+	      return cubehelix$$1;
 	    }(1);
 	  }
 
 	  var cubehelix$2 = cubehelix$1(hue);
 	  var cubehelixLong = cubehelix$1(nogamma);
 
-	  function quantize(interpolator, n) {
+	  var quantize = function quantize(interpolator, n) {
 	    var samples = new Array(n);
 	    for (var i = 0; i < n; ++i) {
 	      samples[i] = interpolator(i / (n - 1));
 	    }return samples;
-	  }
+	  };
 
 	  exports.interpolate = value;
 	  exports.interpolateArray = array;
@@ -4407,23 +4295,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 33 */
+/* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-color/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-color/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
 	  'use strict';
 
-	  function define(constructor, factory, prototype) {
+	  var define = function define(constructor, factory, prototype) {
 	    constructor.prototype = factory.prototype = prototype;
 	    prototype.constructor = constructor;
-	  }
+	  };
 
 	  function extend(parent, definition) {
 	    var prototype = Object.create(parent.prototype);
@@ -4437,14 +4325,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var _darker = 0.7;
 	  var _brighter = 1 / _darker;
 
+	  var reI = "\\s*([+-]?\\d+)\\s*";
+	  var reN = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)\\s*";
+	  var reP = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)%\\s*";
 	  var reHex3 = /^#([0-9a-f]{3})$/;
 	  var reHex6 = /^#([0-9a-f]{6})$/;
-	  var reRgbInteger = /^rgb\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*\)$/;
-	  var reRgbPercent = /^rgb\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/;
-	  var reRgbaInteger = /^rgba\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
-	  var reRgbaPercent = /^rgba\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
-	  var reHslPercent = /^hsl\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/;
-	  var reHslaPercent = /^hsla\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
+	  var reRgbInteger = new RegExp("^rgb\\(" + [reI, reI, reI] + "\\)$");
+	  var reRgbPercent = new RegExp("^rgb\\(" + [reP, reP, reP] + "\\)$");
+	  var reRgbaInteger = new RegExp("^rgba\\(" + [reI, reI, reI, reN] + "\\)$");
+	  var reRgbaPercent = new RegExp("^rgba\\(" + [reP, reP, reP, reN] + "\\)$");
+	  var reHslPercent = new RegExp("^hsl\\(" + [reN, reP, reP] + "\\)$");
+	  var reHslaPercent = new RegExp("^hsla\\(" + [reN, reP, reP, reN] + "\\)$");
+
 	  var named = {
 	    aliceblue: 0xf0f8ff,
 	    antiquewhite: 0xfaebd7,
@@ -4745,6 +4637,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var t1 = 6 / 29;
 	  var t2 = 3 * t1 * t1;
 	  var t3 = t1 * t1 * t1;
+
 	  function labConvert(o) {
 	    if (o instanceof Lab) return new Lab(o.l, o.a, o.b, o.opacity);
 	    if (o instanceof Hcl) {
@@ -4845,6 +4738,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var ED = E * D;
 	  var EB = E * B;
 	  var BC_DA = B * C - D * A;
+
 	  function cubehelixConvert(o) {
 	    if (o instanceof Cubehelix) return new Cubehelix(o.h, o.s, o.l, o.opacity);
 	    if (!(o instanceof Rgb)) o = rgbConvert(o);
@@ -4901,7 +4795,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 34 */
+/* 32 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -5061,7 +4955,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 35 */
+/* 33 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5075,19 +4969,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationProvider = __webpack_require__(36);
+	var _jubilationProvider = __webpack_require__(34);
 
 	var _jubilationProvider2 = _interopRequireDefault(_jubilationProvider);
 
-	var _jubilationContainer = __webpack_require__(48);
+	var _jubilationContainer = __webpack_require__(46);
 
 	var _jubilationContainer2 = _interopRequireDefault(_jubilationContainer);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _chart = __webpack_require__(49);
+	var _chart = __webpack_require__(47);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5114,7 +5008,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 36 */
+/* 34 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5129,15 +5023,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _jubilationContext = __webpack_require__(40);
+	var _jubilationContext = __webpack_require__(38);
 
 	var _jubilationContext2 = _interopRequireDefault(_jubilationContext);
 
@@ -5209,7 +5103,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationProvider;
 
 /***/ },
-/* 37 */
+/* 35 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5222,7 +5116,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	// Unique ID creation requires a high quality random # generator.  We feature
 	// detect to determine the best RNG source, normalizing to a function that
 	// returns 128-bits of randomness, since that's what's usually required
-	var _rng = __webpack_require__(38);
+	var _rng = __webpack_require__(36);
 
 	// Maps for number <-> hex string conversion
 	var _byteToHex = [];
@@ -5393,7 +5287,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = uuid;
 
 /***/ },
-/* 38 */
+/* 36 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
@@ -5431,7 +5325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 39 */
+/* 37 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -5474,7 +5368,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = theme;
 
 /***/ },
-/* 40 */
+/* 38 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5483,9 +5377,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  value: true
 	});
 
-	var _d3Scale = __webpack_require__(41);
+	var _d3Scale = __webpack_require__(39);
 
-	var _provider = __webpack_require__(47);
+	var _provider = __webpack_require__(45);
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -5537,16 +5431,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationContext;
 
 /***/ },
-/* 41 */
+/* 39 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-scale/ Version 1.0.3. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-scale/ Version 1.0.4. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(42), __webpack_require__(43), __webpack_require__(32), __webpack_require__(44), __webpack_require__(45), __webpack_require__(46), __webpack_require__(33)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(42), __webpack_require__(43), __webpack_require__(32), __webpack_require__(44), __webpack_require__(45), __webpack_require__(46), __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(40), __webpack_require__(41), __webpack_require__(30), __webpack_require__(42), __webpack_require__(43), __webpack_require__(44), __webpack_require__(31)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(40), __webpack_require__(41), __webpack_require__(30), __webpack_require__(42), __webpack_require__(43), __webpack_require__(44), __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3);
 	})(undefined, function (exports, d3Array, d3Collection, d3Interpolate, d3Format, d3Time, d3TimeFormat, d3Color) {
 	  'use strict';
 
@@ -5557,12 +5451,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var implicit = { name: "implicit" };
 
-	  function ordinal(range) {
+	  function ordinal(range$$1) {
 	    var index = d3Collection.map(),
 	        domain = [],
 	        unknown = implicit;
 
-	    range = range == null ? [] : slice.call(range);
+	    range$$1 = range$$1 == null ? [] : slice.call(range$$1);
 
 	    function scale(d) {
 	      var key = d + "",
@@ -5571,7 +5465,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (unknown !== implicit) return unknown;
 	        index.set(key, i = domain.push(d));
 	      }
-	      return range[(i - 1) % range.length];
+	      return range$$1[(i - 1) % range$$1.length];
 	    }
 
 	    scale.domain = function (_) {
@@ -5587,7 +5481,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), scale) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), scale) : range$$1.slice();
 	    };
 
 	    scale.unknown = function (_) {
@@ -5595,7 +5489,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return ordinal().domain(domain).range(range).unknown(unknown);
+	      return ordinal().domain(domain).range(range$$1).unknown(unknown);
 	    };
 
 	    return scale;
@@ -5605,7 +5499,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var scale = ordinal().unknown(undefined),
 	        domain = scale.domain,
 	        ordinalRange = scale.range,
-	        range = [0, 1],
+	        range$$1 = [0, 1],
 	        step,
 	        bandwidth,
 	        round = false,
@@ -5617,9 +5511,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    function rescale() {
 	      var n = domain().length,
-	          reverse = range[1] < range[0],
-	          start = range[reverse - 0],
-	          stop = range[1 - reverse];
+	          reverse = range$$1[1] < range$$1[0],
+	          start = range$$1[reverse - 0],
+	          stop = range$$1[1 - reverse];
 	      step = (stop - start) / Math.max(1, n - paddingInner + paddingOuter * 2);
 	      if (round) step = Math.floor(step);
 	      start += (stop - start - step * (n - paddingInner)) * align;
@@ -5636,11 +5530,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = [+_[0], +_[1]], rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = [+_[0], +_[1]], rescale()) : range$$1.slice();
 	    };
 
 	    scale.rangeRound = function (_) {
-	      return range = [+_[0], +_[1]], round = true, rescale();
+	      return range$$1 = [+_[0], +_[1]], round = true, rescale();
 	    };
 
 	    scale.bandwidth = function () {
@@ -5672,7 +5566,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return band().domain(domain()).range(range).round(round).paddingInner(paddingInner).paddingOuter(paddingOuter).align(align);
+	      return band().domain(domain()).range(range$$1).round(round).paddingInner(paddingInner).paddingOuter(paddingOuter).align(align);
 	    };
 
 	    return rescale();
@@ -5696,19 +5590,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return pointish(band().paddingInner(1));
 	  }
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
-	  function number(x) {
+	  var number = function number(x) {
 	    return +x;
-	  }
+	  };
 
 	  var unit = [0, 1];
 
-	  function deinterpolate(a, b) {
+	  function deinterpolateLinear(a, b) {
 	    return (b -= a = +a) ? function (x) {
 	      return (x - a) / b;
 	    } : constant(b);
@@ -5732,19 +5626,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function bimap(domain, range, deinterpolate, reinterpolate) {
+	  function bimap(domain, range$$1, deinterpolate, reinterpolate) {
 	    var d0 = domain[0],
 	        d1 = domain[1],
-	        r0 = range[0],
-	        r1 = range[1];
+	        r0 = range$$1[0],
+	        r1 = range$$1[1];
 	    if (d1 < d0) d0 = deinterpolate(d1, d0), r0 = reinterpolate(r1, r0);else d0 = deinterpolate(d0, d1), r0 = reinterpolate(r0, r1);
 	    return function (x) {
 	      return r0(d0(x));
 	    };
 	  }
 
-	  function polymap(domain, range, deinterpolate, reinterpolate) {
-	    var j = Math.min(domain.length, range.length) - 1,
+	  function polymap(domain, range$$1, deinterpolate, reinterpolate) {
+	    var j = Math.min(domain.length, range$$1.length) - 1,
 	        d = new Array(j),
 	        r = new Array(j),
 	        i = -1;
@@ -5752,12 +5646,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // Reverse descending domains.
 	    if (domain[j] < domain[0]) {
 	      domain = domain.slice().reverse();
-	      range = range.slice().reverse();
+	      range$$1 = range$$1.slice().reverse();
 	    }
 
 	    while (++i < j) {
 	      d[i] = deinterpolate(domain[i], domain[i + 1]);
-	      r[i] = reinterpolate(range[i], range[i + 1]);
+	      r[i] = reinterpolate(range$$1[i], range$$1[i + 1]);
 	    }
 
 	    return function (x) {
@@ -5772,27 +5666,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // deinterpolate(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
 	  // reinterpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding domain value x in [a,b].
-	  function continuous(deinterpolate$$, reinterpolate) {
+	  function continuous(deinterpolate, reinterpolate) {
 	    var domain = unit,
-	        range = unit,
-	        interpolate = d3Interpolate.interpolate,
+	        range$$1 = unit,
+	        interpolate$$1 = d3Interpolate.interpolate,
 	        clamp = false,
 	        piecewise,
 	        output,
 	        input;
 
 	    function rescale() {
-	      piecewise = Math.min(domain.length, range.length) > 2 ? polymap : bimap;
+	      piecewise = Math.min(domain.length, range$$1.length) > 2 ? polymap : bimap;
 	      output = input = null;
 	      return scale;
 	    }
 
 	    function scale(x) {
-	      return (output || (output = piecewise(domain, range, clamp ? deinterpolateClamp(deinterpolate$$) : deinterpolate$$, interpolate)))(+x);
+	      return (output || (output = piecewise(domain, range$$1, clamp ? deinterpolateClamp(deinterpolate) : deinterpolate, interpolate$$1)))(+x);
 	    }
 
 	    scale.invert = function (y) {
-	      return (input || (input = piecewise(range, domain, deinterpolate, clamp ? reinterpolateClamp(reinterpolate) : reinterpolate)))(+y);
+	      return (input || (input = piecewise(range$$1, domain, deinterpolateLinear, clamp ? reinterpolateClamp(reinterpolate) : reinterpolate)))(+y);
 	    };
 
 	    scale.domain = function (_) {
@@ -5800,11 +5694,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), rescale()) : range$$1.slice();
 	    };
 
 	    scale.rangeRound = function (_) {
-	      return range = slice.call(_), interpolate = d3Interpolate.interpolateRound, rescale();
+	      return range$$1 = slice.call(_), interpolate$$1 = d3Interpolate.interpolateRound, rescale();
 	    };
 
 	    scale.clamp = function (_) {
@@ -5812,13 +5706,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.interpolate = function (_) {
-	      return arguments.length ? (interpolate = _, rescale()) : interpolate;
+	      return arguments.length ? (interpolate$$1 = _, rescale()) : interpolate$$1;
 	    };
 
 	    return rescale();
 	  }
 
-	  function tickFormat(domain, count, specifier) {
+	  var tickFormat = function tickFormat(domain, count, specifier) {
 	    var start = domain[0],
 	        stop = domain[domain.length - 1],
 	        step = d3Array.tickStep(start, stop, count == null ? 10 : count),
@@ -5848,7 +5742,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	    }
 	    return d3Format.format(specifier);
-	  }
+	  };
 
 	  function linearish(scale) {
 	    var domain = scale.domain;
@@ -5884,7 +5778,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  function linear() {
-	    var scale = continuous(deinterpolate, d3Interpolate.interpolateNumber);
+	    var scale = continuous(deinterpolateLinear, d3Interpolate.interpolateNumber);
 
 	    scale.copy = function () {
 	      return copy(scale, linear());
@@ -5913,7 +5807,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return linearish(scale);
 	  }
 
-	  function nice(domain, interval) {
+	  var nice = function nice(domain, interval) {
 	    domain = domain.slice();
 
 	    var i0 = 0,
@@ -5930,9 +5824,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    domain[i0] = interval.floor(x0);
 	    domain[i1] = interval.ceil(x1);
 	    return domain;
-	  }
+	  };
 
-	  function deinterpolate$1(a, b) {
+	  function deinterpolate(a, b) {
 	    return (b = Math.log(b / a)) ? function (x) {
 	      return Math.log(x / a) / b;
 	    } : constant(b);
@@ -5969,7 +5863,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  function log() {
-	    var scale = continuous(deinterpolate$1, reinterpolate).domain([1, 10]),
+	    var scale = continuous(deinterpolate, reinterpolate).domain([1, 10]),
 	        domain = scale.domain,
 	        base = 10,
 	        logs = logp(10),
@@ -6099,12 +5993,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  function quantile$1() {
 	    var domain = [],
-	        range = [],
+	        range$$1 = [],
 	        thresholds = [];
 
 	    function rescale() {
 	      var i = 0,
-	          n = Math.max(1, range.length);
+	          n = Math.max(1, range$$1.length);
 	      thresholds = new Array(n - 1);
 	      while (++i < n) {
 	        thresholds[i - 1] = d3Array.quantile(domain, i / n);
@@ -6112,11 +6006,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    function scale(x) {
-	      if (!isNaN(x = +x)) return range[d3Array.bisect(thresholds, x)];
+	      if (!isNaN(x = +x)) return range$$1[d3Array.bisect(thresholds, x)];
 	    }
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return i < 0 ? [NaN, NaN] : [i > 0 ? thresholds[i - 1] : domain[0], i < thresholds.length ? thresholds[i] : domain[domain.length - 1]];
 	    };
 
@@ -6130,7 +6024,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), rescale()) : range$$1.slice();
 	    };
 
 	    scale.quantiles = function () {
@@ -6138,7 +6032,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return quantile$1().domain(domain).range(range);
+	      return quantile$1().domain(domain).range(range$$1);
 	    };
 
 	    return scale;
@@ -6149,10 +6043,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        x1 = 1,
 	        n = 1,
 	        domain = [0.5],
-	        range = [0, 1];
+	        range$$1 = [0, 1];
 
 	    function scale(x) {
-	      if (x <= x) return range[d3Array.bisect(domain, x, 0, n)];
+	      if (x <= x) return range$$1[d3Array.bisect(domain, x, 0, n)];
 	    }
 
 	    function rescale() {
@@ -6168,16 +6062,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (n = (range = slice.call(_)).length - 1, rescale()) : range.slice();
+	      return arguments.length ? (n = (range$$1 = slice.call(_)).length - 1, rescale()) : range$$1.slice();
 	    };
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return i < 0 ? [NaN, NaN] : i < 1 ? [x0, domain[0]] : i >= n ? [domain[n - 1], x1] : [domain[i - 1], domain[i]];
 	    };
 
 	    scale.copy = function () {
-	      return quantize().domain([x0, x1]).range(range);
+	      return quantize().domain([x0, x1]).range(range$$1);
 	    };
 
 	    return linearish(scale);
@@ -6185,28 +6079,28 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  function threshold() {
 	    var domain = [0.5],
-	        range = [0, 1],
+	        range$$1 = [0, 1],
 	        n = 1;
 
 	    function scale(x) {
-	      if (x <= x) return range[d3Array.bisect(domain, x, 0, n)];
+	      if (x <= x) return range$$1[d3Array.bisect(domain, x, 0, n)];
 	    }
 
 	    scale.domain = function (_) {
-	      return arguments.length ? (domain = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : domain.slice();
+	      return arguments.length ? (domain = slice.call(_), n = Math.min(domain.length, range$$1.length - 1), scale) : domain.slice();
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), n = Math.min(domain.length, range$$1.length - 1), scale) : range$$1.slice();
 	    };
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return [domain[i - 1], domain[i]];
 	    };
 
 	    scale.copy = function () {
-	      return threshold().domain(domain).range(range);
+	      return threshold().domain(domain).range(range$$1);
 	    };
 
 	    return scale;
@@ -6219,6 +6113,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var durationWeek = durationDay * 7;
 	  var durationMonth = durationDay * 30;
 	  var durationYear = durationDay * 365;
+
 	  function date(t) {
 	    return new Date(t);
 	  }
@@ -6227,19 +6122,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return t instanceof Date ? +t : +new Date(+t);
 	  }
 
-	  function calendar(year, month, week, day, hour, minute, second, millisecond, format) {
-	    var scale = continuous(deinterpolate, d3Interpolate.interpolateNumber),
+	  function calendar(year, month, week, day, hour, minute, second, millisecond, format$$1) {
+	    var scale = continuous(deinterpolateLinear, d3Interpolate.interpolateNumber),
 	        invert = scale.invert,
 	        domain = scale.domain;
 
-	    var formatMillisecond = format(".%L"),
-	        formatSecond = format(":%S"),
-	        formatMinute = format("%I:%M"),
-	        formatHour = format("%I %p"),
-	        formatDay = format("%a %d"),
-	        formatWeek = format("%b %d"),
-	        formatMonth = format("%B"),
-	        formatYear = format("%Y");
+	    var formatMillisecond = format$$1(".%L"),
+	        formatSecond = format$$1(":%S"),
+	        formatMinute = format$$1("%I:%M"),
+	        formatHour = format$$1("%I %p"),
+	        formatDay = format$$1("%a %d"),
+	        formatWeek = format$$1("%b %d"),
+	        formatMonth = format$$1("%B"),
+	        formatYear = format$$1("%Y");
 
 	    var tickIntervals = [[second, 1, durationSecond], [second, 5, 5 * durationSecond], [second, 15, 15 * durationSecond], [second, 30, 30 * durationSecond], [minute, 1, durationMinute], [minute, 5, 5 * durationMinute], [minute, 15, 15 * durationMinute], [minute, 30, 30 * durationMinute], [hour, 1, durationHour], [hour, 3, 3 * durationHour], [hour, 6, 6 * durationHour], [hour, 12, 12 * durationHour], [day, 1, durationDay], [day, 2, 2 * durationDay], [week, 1, durationWeek], [month, 1, durationMonth], [month, 3, 3 * durationMonth], [year, 1, durationYear]];
 
@@ -6295,7 +6190,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.tickFormat = function (count, specifier) {
-	      return specifier == null ? tickFormat : format(specifier);
+	      return specifier == null ? tickFormat : format$$1(specifier);
 	    };
 
 	    scale.nice = function (interval, step) {
@@ -6304,25 +6199,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return copy(scale, calendar(year, month, week, day, hour, minute, second, millisecond, format));
+	      return copy(scale, calendar(year, month, week, day, hour, minute, second, millisecond, format$$1));
 	    };
 
 	    return scale;
 	  }
 
-	  function time() {
+	  var time = function time() {
 	    return calendar(d3Time.timeYear, d3Time.timeMonth, d3Time.timeWeek, d3Time.timeDay, d3Time.timeHour, d3Time.timeMinute, d3Time.timeSecond, d3Time.timeMillisecond, d3TimeFormat.timeFormat).domain([new Date(2000, 0, 1), new Date(2000, 0, 2)]);
-	  }
+	  };
 
-	  function utcTime() {
+	  var utcTime = function utcTime() {
 	    return calendar(d3Time.utcYear, d3Time.utcMonth, d3Time.utcWeek, d3Time.utcDay, d3Time.utcHour, d3Time.utcMinute, d3Time.utcSecond, d3Time.utcMillisecond, d3TimeFormat.utcFormat).domain([Date.UTC(2000, 0, 1), Date.UTC(2000, 0, 2)]);
-	  }
+	  };
 
-	  function colors(s) {
+	  var colors = function colors(s) {
 	    return s.match(/.{6}/g).map(function (x) {
 	      return "#" + x;
 	    });
-	  }
+	  };
 
 	  var category10 = colors("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
 
@@ -6340,19 +6235,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var rainbow = d3Color.cubehelix();
 
-	  function rainbow$1(t) {
+	  var rainbow$1 = function rainbow$1(t) {
 	    if (t < 0 || t > 1) t -= Math.floor(t);
 	    var ts = Math.abs(t - 0.5);
 	    rainbow.h = 360 * t - 100;
 	    rainbow.s = 1.5 - 1.5 * ts;
 	    rainbow.l = 0.8 - 0.9 * ts;
 	    return rainbow + "";
-	  }
+	  };
 
-	  function ramp(range) {
-	    var n = range.length;
+	  function ramp(range$$1) {
+	    var n = range$$1.length;
 	    return function (t) {
-	      return range[Math.max(0, Math.min(n - 1, Math.floor(t * n)))];
+	      return range$$1[Math.max(0, Math.min(n - 1, Math.floor(t * n)))];
 	    };
 	  }
 
@@ -6425,24 +6320,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 42 */
+/* 40 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-array/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-array/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
 	  'use strict';
 
-	  function ascending(a, b) {
+	  var ascending = function ascending(a, b) {
 	    return a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
-	  }
+	  };
 
-	  function bisector(compare) {
+	  var bisector = function bisector(compare) {
 	    if (compare.length === 1) compare = ascendingComparator(compare);
 	    return {
 	      left: function left(a, x, lo, hi) {
@@ -6464,7 +6359,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return lo;
 	      }
 	    };
-	  }
+	  };
 
 	  function ascendingComparator(f) {
 	    return function (d, x) {
@@ -6476,15 +6371,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var bisectRight = ascendingBisect.right;
 	  var bisectLeft = ascendingBisect.left;
 
-	  function descending(a, b) {
+	  var descending = function descending(a, b) {
 	    return b < a ? -1 : b > a ? 1 : b >= a ? 0 : NaN;
-	  }
+	  };
 
-	  function number(x) {
+	  var number = function number(x) {
 	    return x === null ? NaN : +x;
-	  }
+	  };
 
-	  function variance(array, f) {
+	  var variance = function variance(array, f) {
 	    var n = array.length,
 	        m = 0,
 	        a,
@@ -6512,14 +6407,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    if (j > 1) return s / (j - 1);
-	  }
+	  };
 
-	  function deviation(array, f) {
+	  var deviation = function deviation(array, f) {
 	    var v = variance(array, f);
 	    return v ? Math.sqrt(v) : v;
-	  }
+	  };
 
-	  function extent(array, f) {
+	  var extent = function extent(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6551,24 +6446,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return [a, c];
-	  }
+	  };
 
 	  var array = Array.prototype;
 
 	  var slice = array.slice;
 	  var map = array.map;
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
-	  function identity(x) {
+	  var identity = function identity(x) {
 	    return x;
-	  }
+	  };
 
-	  function range(start, stop, step) {
+	  var range = function range(start, stop, step) {
 	    start = +start, stop = +stop, step = (n = arguments.length) < 2 ? (stop = start, start = 0, 1) : n < 3 ? 1 : +step;
 
 	    var i = -1,
@@ -6580,16 +6475,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return range;
-	  }
+	  };
 
 	  var e10 = Math.sqrt(50);
 	  var e5 = Math.sqrt(10);
 	  var e2 = Math.sqrt(2);
-	  function ticks(start, stop, count) {
+
+	  var ticks = function ticks(start, stop, count) {
 	    var step = tickStep(start, stop, count);
 	    return range(Math.ceil(start / step) * step, Math.floor(stop / step) * step + step / 2, // inclusive
 	    step);
-	  }
+	  };
 
 	  function tickStep(start, stop, count) {
 	    var step0 = Math.abs(stop - start) / Math.max(0, count),
@@ -6599,11 +6495,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return stop < start ? -step1 : step1;
 	  }
 
-	  function sturges(values) {
+	  var sturges = function sturges(values) {
 	    return Math.ceil(Math.log(values.length) / Math.LN2) + 1;
-	  }
+	  };
 
-	  function histogram() {
+	  var histogram = function histogram() {
 	    var value = identity,
 	        domain = extent,
 	        threshold = sturges;
@@ -6666,9 +6562,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    return histogram;
-	  }
+	  };
 
-	  function quantile(array, p, f) {
+	  var quantile = function quantile(array, p, f) {
 	    if (f == null) f = number;
 	    if (!(n = array.length)) return;
 	    if ((p = +p) <= 0 || n < 2) return +f(array[0], 0, array);
@@ -6679,18 +6575,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	        a = +f(array[i], i, array),
 	        b = +f(array[i + 1], i + 1, array);
 	    return a + (b - a) * (h - i);
-	  }
+	  };
 
-	  function freedmanDiaconis(values, min, max) {
+	  var freedmanDiaconis = function freedmanDiaconis(values, min, max) {
 	    values = map.call(values, number).sort(ascending);
 	    return Math.ceil((max - min) / (2 * (quantile(values, 0.75) - quantile(values, 0.25)) * Math.pow(values.length, -1 / 3)));
-	  }
+	  };
 
-	  function scott(values, min, max) {
+	  var scott = function scott(values, min, max) {
 	    return Math.ceil((max - min) / (3.5 * deviation(values) * Math.pow(values.length, -1 / 3)));
-	  }
+	  };
 
-	  function max(array, f) {
+	  var max = function max(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6715,9 +6611,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return a;
-	  }
+	  };
 
-	  function mean(array, f) {
+	  var mean = function mean(array, f) {
 	    var s = 0,
 	        n = array.length,
 	        a,
@@ -6735,9 +6631,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    if (j) return s / j;
-	  }
+	  };
 
-	  function median(array, f) {
+	  var median = function median(array, f) {
 	    var numbers = [],
 	        n = array.length,
 	        a,
@@ -6754,9 +6650,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return quantile(numbers.sort(ascending), 0.5);
-	  }
+	  };
 
-	  function merge(arrays) {
+	  var merge = function merge(arrays) {
 	    var n = arrays.length,
 	        m,
 	        i = -1,
@@ -6777,9 +6673,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return merged;
-	  }
+	  };
 
-	  function min(array, f) {
+	  var min = function min(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6804,9 +6700,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return a;
-	  }
+	  };
 
-	  function pairs(array) {
+	  var pairs = function pairs(array) {
 	    var i = 0,
 	        n = array.length - 1,
 	        p = array[0],
@@ -6814,17 +6710,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    while (i < n) {
 	      pairs[i] = [p, p = array[++i]];
 	    }return pairs;
-	  }
+	  };
 
-	  function permute(array, indexes) {
+	  var permute = function permute(array, indexes) {
 	    var i = indexes.length,
 	        permutes = new Array(i);
 	    while (i--) {
 	      permutes[i] = array[indexes[i]];
 	    }return permutes;
-	  }
+	  };
 
-	  function scan(array, compare) {
+	  var scan = function scan(array, compare) {
 	    if (!(n = array.length)) return;
 	    var i = 0,
 	        n,
@@ -6837,9 +6733,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    while (++i < n) {
 	      if (compare(xi = array[i], xj) < 0 || compare(xj, xj) !== 0) xj = xi, j = i;
 	    }if (compare(xj, xj) === 0) return j;
-	  }
+	  };
 
-	  function shuffle(array, i0, i1) {
+	  var shuffle = function shuffle(array, i0, i1) {
 	    var m = (i1 == null ? array.length : i1) - (i0 = i0 == null ? 0 : +i0),
 	        t,
 	        i;
@@ -6852,9 +6748,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return array;
-	  }
+	  };
 
-	  function sum(array, f) {
+	  var sum = function sum(array, f) {
 	    var s = 0,
 	        n = array.length,
 	        a,
@@ -6871,9 +6767,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return s;
-	  }
+	  };
 
-	  function transpose(matrix) {
+	  var transpose = function transpose(matrix) {
 	    if (!(n = matrix.length)) return [];
 	    for (var i = -1, m = min(matrix, length), transpose = new Array(m); ++i < m;) {
 	      for (var j = -1, n, row = transpose[i] = new Array(n); ++j < n;) {
@@ -6881,15 +6777,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	    return transpose;
-	  }
+	  };
 
 	  function length(d) {
 	    return d.length;
 	  }
 
-	  function zip() {
+	  var zip = function zip() {
 	    return transpose(arguments);
-	  }
+	  };
 
 	  exports.bisect = bisectRight;
 	  exports.bisectRight = bisectRight;
@@ -6925,14 +6821,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 43 */
+/* 41 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-collection/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-collection/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
@@ -7026,7 +6922,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }return map;
 	  }
 
-	  function nest() {
+	  var nest = function nest() {
 	    var keys = [],
 	        _sortKeys = [],
 	        _sortValues,
@@ -7060,11 +6956,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return result;
 	    }
 
-	    function _entries(map, depth) {
-	      if (++depth > keys.length) return map;
+	    function _entries(map$$1, depth) {
+	      if (++depth > keys.length) return map$$1;
 	      var array,
 	          sortKey = _sortKeys[depth - 1];
-	      if (_rollup != null && depth >= keys.length) array = map.entries();else array = [], map.each(function (v, k) {
+	      if (_rollup != null && depth >= keys.length) array = map$$1.entries();else array = [], map$$1.each(function (v, k) {
 	        array.push({ key: k, values: _entries(v, depth) });
 	      });
 	      return sortKey != null ? array.sort(function (a, b) {
@@ -7095,7 +6991,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        _rollup = f;return nest;
 	      }
 	    };
-	  }
+	  };
 
 	  function createObject() {
 	    return {};
@@ -7109,8 +7005,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return map();
 	  }
 
-	  function setMap(map, key, value) {
-	    map.set(key, value);
+	  function setMap(map$$1, key, value) {
+	    map$$1.set(key, value);
 	  }
 
 	  function Set() {}
@@ -7155,26 +7051,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return set;
 	  }
 
-	  function keys(map) {
+	  var keys = function keys(map) {
 	    var keys = [];
 	    for (var key in map) {
 	      keys.push(key);
 	    }return keys;
-	  }
+	  };
 
-	  function values(map) {
+	  var values = function values(map) {
 	    var values = [];
 	    for (var key in map) {
 	      values.push(map[key]);
 	    }return values;
-	  }
+	  };
 
-	  function entries(map) {
+	  var entries = function entries(map) {
 	    var entries = [];
 	    for (var key in map) {
 	      entries.push({ key: key, value: map[key] });
 	    }return entries;
-	  }
+	  };
 
 	  exports.nest = nest;
 	  exports.set = set;
@@ -7187,7 +7083,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 44 */
+/* 42 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -7536,7 +7432,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 45 */
+/* 43 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -7927,16 +7823,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 46 */
+/* 44 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-time-format/ Version 2.0.2. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-time-format/ Version 2.0.3. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(45)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(45)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(43)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(43)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
 	})(undefined, function (exports, d3Time) {
 	  'use strict';
 
@@ -8264,6 +8160,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var numberRe = /^\s*\d+/;
 	  var percentRe = /^%/;
 	  var requoteRe = /[\\\^\$\*\+\?\|\[\]\(\)\.\{\}]/g;
+
 	  function pad(value, fill, width) {
 	    var sign = value < 0 ? "-" : "",
 	        string = (sign ? -value : value) + "",
@@ -8475,7 +8372,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return "%";
 	  }
 
-	  var locale;
+	  var locale$1;
+
 	  defaultLocale({
 	    dateTime: "%x, %X",
 	    date: "%-m/%-d/%Y",
@@ -8488,12 +8386,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  });
 
 	  function defaultLocale(definition) {
-	    locale = formatLocale(definition);
-	    exports.timeFormat = locale.format;
-	    exports.timeParse = locale.parse;
-	    exports.utcFormat = locale.utcFormat;
-	    exports.utcParse = locale.utcParse;
-	    return locale;
+	    locale$1 = formatLocale(definition);
+	    exports.timeFormat = locale$1.format;
+	    exports.timeParse = locale$1.parse;
+	    exports.utcFormat = locale$1.utcFormat;
+	    exports.utcParse = locale$1.utcParse;
+	    return locale$1;
 	  }
 
 	  var isoSpecifier = "%Y-%m-%dT%H:%M:%S.%LZ";
@@ -8520,7 +8418,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 47 */
+/* 45 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -8586,7 +8484,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 48 */
+/* 46 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8655,7 +8553,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 49 */
+/* 47 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -8683,7 +8581,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 50 */
+/* 48 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8700,7 +8598,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -8764,7 +8662,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationLabel.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 51 */
+/* 49 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8775,7 +8673,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.defaultContext = undefined;
 	exports.default = getContext;
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
@@ -8818,7 +8716,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 52 */
+/* 50 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8832,7 +8730,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -8882,7 +8780,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationPoint.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 53 */
+/* 51 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8899,15 +8797,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationPoint = __webpack_require__(52);
+	var _jubilationPoint = __webpack_require__(50);
 
 	var _jubilationPoint2 = _interopRequireDefault(_jubilationPoint);
 
@@ -8965,7 +8863,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationScatter;
 
 /***/ },
-/* 54 */
+/* 52 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -9002,7 +8900,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 55 */
+/* 53 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9017,31 +8915,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationRect = __webpack_require__(56);
+	var _jubilationRect = __webpack_require__(54);
 
 	var _jubilationRect2 = _interopRequireDefault(_jubilationRect);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _text = __webpack_require__(58);
+	var _text = __webpack_require__(56);
 
 	var _text2 = _interopRequireDefault(_text);
 
@@ -9185,7 +9083,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationHorizontalBarChart;
 
 /***/ },
-/* 56 */
+/* 54 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9199,7 +9097,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -9256,7 +9154,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationRect.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 57 */
+/* 55 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -9288,7 +9186,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 58 */
+/* 56 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9298,7 +9196,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = getTextWidth;
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
@@ -9321,7 +9219,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 59 */
+/* 57 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9336,27 +9234,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationRect = __webpack_require__(56);
+	var _jubilationRect = __webpack_require__(54);
 
 	var _jubilationRect2 = _interopRequireDefault(_jubilationRect);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
@@ -9485,7 +9383,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationVerticalBarChart;
 
 /***/ },
-/* 60 */
+/* 58 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9495,11 +9393,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.YAxis = exports.XAxis = undefined;
 
-	var _xAxis = __webpack_require__(61);
+	var _xAxis = __webpack_require__(59);
 
 	var _xAxis2 = _interopRequireDefault(_xAxis);
 
-	var _yAxis = __webpack_require__(66);
+	var _yAxis = __webpack_require__(64);
 
 	var _yAxis2 = _interopRequireDefault(_yAxis);
 
@@ -9509,7 +9407,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.YAxis = _yAxis2.default;
 
 /***/ },
-/* 61 */
+/* 59 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9523,21 +9421,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _jubilationTick = __webpack_require__(62);
+	var _jubilationTick = __webpack_require__(60);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9650,7 +9548,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	XAxis.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 62 */
+/* 60 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9660,11 +9558,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.YTick = exports.XTick = undefined;
 
-	var _xTick = __webpack_require__(63);
+	var _xTick = __webpack_require__(61);
 
 	var _xTick2 = _interopRequireDefault(_xTick);
 
-	var _yTick = __webpack_require__(65);
+	var _yTick = __webpack_require__(63);
 
 	var _yTick2 = _interopRequireDefault(_yTick);
 
@@ -9674,7 +9572,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.YTick = _yTick2.default;
 
 /***/ },
-/* 63 */
+/* 61 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9691,7 +9589,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9729,7 +9627,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 64 */
+/* 62 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9746,7 +9644,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -9762,6 +9660,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * A line segment, defined by two endpoints. Returns an SVG line element.
 	 */
 	function JubilationLine(_ref, _ref2) {
+	  var JubilationContext = _ref2.JubilationContext;
+
 	  var _ref$x = _ref.x1,
 	      x1 = _ref$x === undefined ? 0 : _ref$x,
 	      _ref$y = _ref.y1,
@@ -9771,8 +9671,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	      _ref$y2 = _ref.y2,
 	      y2 = _ref$y2 === undefined ? 1 : _ref$y2,
 	      rest = _objectWithoutProperties(_ref, ['x1', 'y1', 'x2', 'y2']);
-
-	  var JubilationContext = _ref2.JubilationContext;
 
 	  var context = (0, _context2.default)(JubilationContext);
 	  var xScale = context.xScale,
@@ -9798,7 +9696,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationLine.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 65 */
+/* 63 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9815,7 +9713,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9853,7 +9751,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 66 */
+/* 64 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9867,21 +9765,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _jubilationTick = __webpack_require__(62);
+	var _jubilationTick = __webpack_require__(60);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -60,36 +60,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _reactDom = __webpack_require__(67);
+	var _reactDom = __webpack_require__(65);
 
 	var _reactDom2 = _interopRequireDefault(_reactDom);
 
-	var _axis = __webpack_require__(200);
+	var _examples = __webpack_require__(203);
 
-	var _axis2 = _interopRequireDefault(_axis);
-
-	var _barplot = __webpack_require__(201);
-
-	var _barplot2 = _interopRequireDefault(_barplot);
-
-	var _scatterplot = __webpack_require__(202);
-
-	var _scatterplot2 = _interopRequireDefault(_scatterplot);
+	var _examples2 = _interopRequireDefault(_examples);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	_reactDom2.default.render(_react2.default.createElement(
-	  'div',
-	  null,
-	  _react2.default.createElement(
-	    'h1',
-	    null,
-	    'Axis Examples'
-	  ),
-	  _react2.default.createElement(_axis2.default, null),
-	  _react2.default.createElement(_barplot2.default, null),
-	  _react2.default.createElement(_scatterplot2.default, null)
-	), document.getElementById('root'));
+	_reactDom2.default.render(_react2.default.createElement(_examples2.default, null), document.getElementById('root'));
 
 /***/ },
 /* 1 */
@@ -107,13 +88,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _d3Ease = __webpack_require__(31);
+	var _d3Ease = __webpack_require__(29);
 
 	var d3Ease = _interopRequireWildcard(_d3Ease);
 
-	var _d3Interpolate = __webpack_require__(32);
+	var _d3Interpolate = __webpack_require__(30);
 
-	var _d3Timer = __webpack_require__(34);
+	var _d3Timer = __webpack_require__(32);
 
 	function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
@@ -267,7 +248,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule React
 	 */
 
 	'use strict';
@@ -275,15 +255,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _assign = __webpack_require__(4);
 
 	var ReactChildren = __webpack_require__(5);
-	var ReactComponent = __webpack_require__(17);
-	var ReactPureComponent = __webpack_require__(20);
-	var ReactClass = __webpack_require__(21);
-	var ReactDOMFactories = __webpack_require__(26);
+	var ReactComponent = __webpack_require__(18);
+	var ReactPureComponent = __webpack_require__(21);
+	var ReactClass = __webpack_require__(22);
+	var ReactDOMFactories = __webpack_require__(24);
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypes = __webpack_require__(27);
-	var ReactVersion = __webpack_require__(29);
+	var ReactPropTypes = __webpack_require__(25);
+	var ReactVersion = __webpack_require__(27);
 
-	var onlyChild = __webpack_require__(30);
+	var onlyChild = __webpack_require__(28);
 	var warning = __webpack_require__(11);
 
 	var createElement = ReactElement.createElement;
@@ -449,7 +429,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactChildren
 	 */
 
 	'use strict';
@@ -458,7 +437,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var ReactElement = __webpack_require__(9);
 
 	var emptyFunction = __webpack_require__(12);
-	var traverseAllChildren = __webpack_require__(14);
+	var traverseAllChildren = __webpack_require__(15);
 
 	var twoArgumentPooler = PooledClass.twoArgumentPooler;
 	var fourArgumentPooler = PooledClass.fourArgumentPooler;
@@ -489,8 +468,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	PooledClass.addPoolingTo(ForEachBookKeeping, twoArgumentPooler);
 
 	function forEachSingleChild(bookKeeping, child, name) {
-	  var func = bookKeeping.func;
-	  var context = bookKeeping.context;
+	  var func = bookKeeping.func,
+	      context = bookKeeping.context;
 
 	  func.call(context, child, bookKeeping.count++);
 	}
@@ -542,10 +521,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	PooledClass.addPoolingTo(MapBookKeeping, fourArgumentPooler);
 
 	function mapSingleChildIntoContext(bookKeeping, child, childKey) {
-	  var result = bookKeeping.result;
-	  var keyPrefix = bookKeeping.keyPrefix;
-	  var func = bookKeeping.func;
-	  var context = bookKeeping.context;
+	  var result = bookKeeping.result,
+	      keyPrefix = bookKeeping.keyPrefix,
+	      func = bookKeeping.func,
+	      context = bookKeeping.context;
 
 	  var mappedChild = func.call(context, child, bookKeeping.count++);
 	  if (Array.isArray(mappedChild)) {
@@ -644,7 +623,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule PooledClass
+	 * 
 	 */
 
 	'use strict';
@@ -737,6 +716,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param {Function} pooler Customizable pooler.
 	 */
 	var addPoolingTo = function addPoolingTo(CopyConstructor, pooler) {
+	  // Casting as any so that flow ignores the actual implementation and trusts
+	  // it to match the type we declared
 	  var NewKlass = CopyConstructor;
 	  NewKlass.instancePool = [];
 	  NewKlass.getPooled = pooler || DEFAULT_POOLER;
@@ -770,7 +751,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule reactProdInvariant
 	 * 
 	 */
 	'use strict';
@@ -868,7 +848,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactElement
 	 */
 
 	'use strict';
@@ -883,9 +862,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var canDefineProperty = __webpack_require__(13);
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-	// The Symbol used to tag the ReactElement type. If there is no native Symbol
-	// nor polyfill, then a plain number is used for performance.
-	var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+	var REACT_ELEMENT_TYPE = __webpack_require__(14);
 
 	var RESERVED_PROPS = {
 	  key: true,
@@ -989,7 +966,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // This can be replaced with a WeakMap once they are implemented in
 	    // commonly used development environments.
 	    element._store = {};
-	    var shadowChildren = Array.isArray(props.children) ? props.children.slice(0) : props.children;
 
 	    // To make comparing ReactElements easier for testing purposes, we make
 	    // the validation flag non-enumerable (where possible, which should
@@ -1009,12 +985,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	        writable: false,
 	        value: self
 	      });
-	      Object.defineProperty(element, '_shadowChildren', {
-	        configurable: false,
-	        enumerable: false,
-	        writable: false,
-	        value: shadowChildren
-	      });
 	      // Two elements created in two different places should be considered
 	      // equal for testing purposes and therefore we hide it from enumeration.
 	      Object.defineProperty(element, '_source', {
@@ -1026,7 +996,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    } else {
 	      element._store.validated = false;
 	      element._self = self;
-	      element._shadowChildren = shadowChildren;
 	      element._source = source;
 	    }
 	    if (Object.freeze) {
@@ -1080,6 +1049,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var childArray = Array(childrenLength);
 	    for (var i = 0; i < childrenLength; i++) {
 	      childArray[i] = arguments[i + 2];
+	    }
+	    if (false) {
+	      if (Object.freeze) {
+	        Object.freeze(childArray);
+	      }
 	    }
 	    props.children = childArray;
 	  }
@@ -1207,8 +1181,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return (typeof object === 'undefined' ? 'undefined' : _typeof(object)) === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
 	};
 
-	ReactElement.REACT_ELEMENT_TYPE = REACT_ELEMENT_TYPE;
-
 	module.exports = ReactElement;
 
 /***/ },
@@ -1223,7 +1195,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactCurrentOwner
+	 * 
 	 */
 
 	'use strict';
@@ -1373,7 +1345,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule canDefineProperty
+	 * 
 	 */
 
 	'use strict';
@@ -1381,6 +1353,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var canDefineProperty = false;
 	if (false) {
 	  try {
+	    // $FlowFixMe https://github.com/facebook/flow/issues/285
 	    Object.defineProperty({}, 'x', { get: function get() {} });
 	    canDefineProperty = true;
 	  } catch (x) {
@@ -1392,6 +1365,30 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 /* 14 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2014-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	// The Symbol used to tag the ReactElement type. If there is no native Symbol
+	// nor polyfill, then a plain number is used for performance.
+
+	var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+	module.exports = REACT_ELEMENT_TYPE;
+
+/***/ },
+/* 15 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1402,7 +1399,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule traverseAllChildren
 	 */
 
 	'use strict';
@@ -1412,15 +1408,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _prodInvariant = __webpack_require__(7);
 
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactElement = __webpack_require__(9);
+	var REACT_ELEMENT_TYPE = __webpack_require__(14);
 
-	var getIteratorFn = __webpack_require__(15);
+	var getIteratorFn = __webpack_require__(16);
 	var invariant = __webpack_require__(8);
-	var KeyEscapeUtils = __webpack_require__(16);
+	var KeyEscapeUtils = __webpack_require__(17);
 	var warning = __webpack_require__(11);
 
 	var SEPARATOR = '.';
 	var SUBSEPARATOR = ':';
+
+	/**
+	 * This is inlined from ReactElement since this file is shared between
+	 * isomorphic and renderers. We could extract this to a
+	 *
+	 */
 
 	/**
 	 * TODO: Test that a single child and an array with one item have the same key
@@ -1463,7 +1465,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    children = null;
 	  }
 
-	  if (children === null || type === 'string' || type === 'number' || ReactElement.isValidElement(children)) {
+	  if (children === null || type === 'string' || type === 'number' ||
+	  // The following is inlined from ReactElement. This means we can optimize
+	  // some checks. React Fiber also inlines this logic for similar purposes.
+	  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
 	    callback(traverseContext, children,
 	    // If it's the only child, treat the name as if it was wrapped in an array
 	    // so that it's consistent if the number of children grows.
@@ -1565,7 +1570,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = traverseAllChildren;
 
 /***/ },
-/* 15 */
+/* 16 */
 /***/ function(module, exports) {
 
 	/**
@@ -1576,7 +1581,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getIteratorFn
 	 * 
 	 */
 
@@ -1611,7 +1615,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getIteratorFn;
 
 /***/ },
-/* 16 */
+/* 17 */
 /***/ function(module, exports) {
 
 	/**
@@ -1622,7 +1626,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule KeyEscapeUtils
 	 * 
 	 */
 
@@ -1675,7 +1678,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = KeyEscapeUtils;
 
 /***/ },
-/* 17 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1686,7 +1689,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactComponent
 	 */
 
 	'use strict';
@@ -1695,10 +1697,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _prodInvariant = __webpack_require__(7);
 
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
 	var canDefineProperty = __webpack_require__(13);
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
 
@@ -1800,7 +1802,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactComponent;
 
 /***/ },
-/* 18 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1811,7 +1813,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactNoopUpdateQueue
 	 */
 
 	'use strict';
@@ -1901,7 +1902,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactNoopUpdateQueue;
 
 /***/ },
-/* 19 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1925,7 +1926,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = emptyObject;
 
 /***/ },
-/* 20 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1936,17 +1937,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPureComponent
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var ReactComponent = __webpack_require__(17);
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactComponent = __webpack_require__(18);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 
 	/**
 	 * Base class helpers for the updating state of a component.
@@ -1972,7 +1972,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPureComponent;
 
 /***/ },
-/* 21 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -1983,7 +1983,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactClass
 	 */
 
 	'use strict';
@@ -1993,44 +1992,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _prodInvariant = __webpack_require__(7),
 	    _assign = __webpack_require__(4);
 
-	var ReactComponent = __webpack_require__(17);
+	var ReactComponent = __webpack_require__(18);
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypeLocations = __webpack_require__(22);
-	var ReactPropTypeLocationNames = __webpack_require__(24);
-	var ReactNoopUpdateQueue = __webpack_require__(18);
+	var ReactPropTypeLocationNames = __webpack_require__(23);
+	var ReactNoopUpdateQueue = __webpack_require__(19);
 
-	var emptyObject = __webpack_require__(19);
+	var emptyObject = __webpack_require__(20);
 	var invariant = __webpack_require__(8);
-	var keyMirror = __webpack_require__(23);
-	var keyOf = __webpack_require__(25);
 	var warning = __webpack_require__(11);
 
-	var MIXINS_KEY = keyOf({ mixins: null });
+	var MIXINS_KEY = 'mixins';
+
+	// Helper function to allow the creation of anonymous functions which do not
+	// have .name set to the name of the variable being assigned to.
+	function identity(fn) {
+	  return fn;
+	}
 
 	/**
 	 * Policies that describe methods in `ReactClassInterface`.
 	 */
-	var SpecPolicy = keyMirror({
-	  /**
-	   * These methods may be defined only once by the class specification or mixin.
-	   */
-	  DEFINE_ONCE: null,
-	  /**
-	   * These methods may be defined by both the class specification and mixins.
-	   * Subsequent definitions will be chained. These methods must return void.
-	   */
-	  DEFINE_MANY: null,
-	  /**
-	   * These methods are overriding the base class.
-	   */
-	  OVERRIDE_BASE: null,
-	  /**
-	   * These methods are similar to DEFINE_MANY, except we assume they return
-	   * objects. We try to merge the keys of the return values of all the mixed in
-	   * functions. If there is a key conflict we throw.
-	   */
-	  DEFINE_MANY_MERGED: null
-	});
 
 	var injectedMixins = [];
 
@@ -2064,7 +2045,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {array}
 	   * @optional
 	   */
-	  mixins: SpecPolicy.DEFINE_MANY,
+	  mixins: 'DEFINE_MANY',
 
 	  /**
 	   * An object containing properties and methods that should be defined on
@@ -2073,7 +2054,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  statics: SpecPolicy.DEFINE_MANY,
+	  statics: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of prop types for this component.
@@ -2081,7 +2062,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  propTypes: SpecPolicy.DEFINE_MANY,
+	  propTypes: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of context types for this component.
@@ -2089,7 +2070,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  contextTypes: SpecPolicy.DEFINE_MANY,
+	  contextTypes: 'DEFINE_MANY',
 
 	  /**
 	   * Definition of context types this component sets for its children.
@@ -2097,7 +2078,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {object}
 	   * @optional
 	   */
-	  childContextTypes: SpecPolicy.DEFINE_MANY,
+	  childContextTypes: 'DEFINE_MANY',
 
 	  // ==== Definition methods ====
 
@@ -2111,7 +2092,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {object}
 	   * @optional
 	   */
-	  getDefaultProps: SpecPolicy.DEFINE_MANY_MERGED,
+	  getDefaultProps: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * Invoked once before the component is mounted. The return value will be used
@@ -2127,13 +2108,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {object}
 	   * @optional
 	   */
-	  getInitialState: SpecPolicy.DEFINE_MANY_MERGED,
+	  getInitialState: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * @return {object}
 	   * @optional
 	   */
-	  getChildContext: SpecPolicy.DEFINE_MANY_MERGED,
+	  getChildContext: 'DEFINE_MANY_MERGED',
 
 	  /**
 	   * Uses props from `this.props` and state from `this.state` to render the
@@ -2151,7 +2132,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @nosideeffects
 	   * @required
 	   */
-	  render: SpecPolicy.DEFINE_ONCE,
+	  render: 'DEFINE_ONCE',
 
 	  // ==== Delegate methods ====
 
@@ -2162,7 +2143,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @optional
 	   */
-	  componentWillMount: SpecPolicy.DEFINE_MANY,
+	  componentWillMount: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component has been mounted and has a DOM representation.
@@ -2174,7 +2155,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {DOMElement} rootNode DOM element representing the component.
 	   * @optional
 	   */
-	  componentDidMount: SpecPolicy.DEFINE_MANY,
+	  componentDidMount: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked before the component receives new props.
@@ -2195,7 +2176,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {object} nextProps
 	   * @optional
 	   */
-	  componentWillReceiveProps: SpecPolicy.DEFINE_MANY,
+	  componentWillReceiveProps: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked while deciding if the component should be updated as a result of
@@ -2217,7 +2198,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {boolean} True if the component should update.
 	   * @optional
 	   */
-	  shouldComponentUpdate: SpecPolicy.DEFINE_ONCE,
+	  shouldComponentUpdate: 'DEFINE_ONCE',
 
 	  /**
 	   * Invoked when the component is about to update due to a transition from
@@ -2234,7 +2215,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {ReactReconcileTransaction} transaction
 	   * @optional
 	   */
-	  componentWillUpdate: SpecPolicy.DEFINE_MANY,
+	  componentWillUpdate: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component's DOM representation has been updated.
@@ -2248,7 +2229,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {DOMElement} rootNode DOM element representing the component.
 	   * @optional
 	   */
-	  componentDidUpdate: SpecPolicy.DEFINE_MANY,
+	  componentDidUpdate: 'DEFINE_MANY',
 
 	  /**
 	   * Invoked when the component is about to be removed from its parent and have
@@ -2261,7 +2242,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @optional
 	   */
-	  componentWillUnmount: SpecPolicy.DEFINE_MANY,
+	  componentWillUnmount: 'DEFINE_MANY',
 
 	  // ==== Advanced methods ====
 
@@ -2275,7 +2256,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @internal
 	   * @overridable
 	   */
-	  updateComponent: SpecPolicy.OVERRIDE_BASE
+	  updateComponent: 'OVERRIDE_BASE'
 
 	};
 
@@ -2301,13 +2282,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  childContextTypes: function childContextTypes(Constructor, _childContextTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _childContextTypes, ReactPropTypeLocations.childContext);
+	      validateTypeDef(Constructor, _childContextTypes, 'childContext');
 	    }
 	    Constructor.childContextTypes = _assign({}, Constructor.childContextTypes, _childContextTypes);
 	  },
 	  contextTypes: function contextTypes(Constructor, _contextTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _contextTypes, ReactPropTypeLocations.context);
+	      validateTypeDef(Constructor, _contextTypes, 'context');
 	    }
 	    Constructor.contextTypes = _assign({}, Constructor.contextTypes, _contextTypes);
 	  },
@@ -2324,7 +2305,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  propTypes: function propTypes(Constructor, _propTypes) {
 	    if (false) {
-	      validateTypeDef(Constructor, _propTypes, ReactPropTypeLocations.prop);
+	      validateTypeDef(Constructor, _propTypes, 'prop');
 	    }
 	    Constructor.propTypes = _assign({}, Constructor.propTypes, _propTypes);
 	  },
@@ -2333,7 +2314,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 	  autobind: function autobind() {} };
 
-	// noop
 	function validateTypeDef(Constructor, typeDef, location) {
 	  for (var propName in typeDef) {
 	    if (typeDef.hasOwnProperty(propName)) {
@@ -2349,12 +2329,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Disallow overriding of base class methods unless explicitly allowed.
 	  if (ReactClassMixin.hasOwnProperty(name)) {
-	    !(specPolicy === SpecPolicy.OVERRIDE_BASE) ?  false ? invariant(false, 'ReactClassInterface: You are attempting to override `%s` from your class specification. Ensure that your method names do not overlap with React methods.', name) : _prodInvariant('73', name) : void 0;
+	    !(specPolicy === 'OVERRIDE_BASE') ?  false ? invariant(false, 'ReactClassInterface: You are attempting to override `%s` from your class specification. Ensure that your method names do not overlap with React methods.', name) : _prodInvariant('73', name) : void 0;
 	  }
 
 	  // Disallow defining methods more than once unless explicitly allowed.
 	  if (isAlreadyDefined) {
-	    !(specPolicy === SpecPolicy.DEFINE_MANY || specPolicy === SpecPolicy.DEFINE_MANY_MERGED) ?  false ? invariant(false, 'ReactClassInterface: You are attempting to define `%s` on your component more than once. This conflict may be due to a mixin.', name) : _prodInvariant('74', name) : void 0;
+	    !(specPolicy === 'DEFINE_MANY' || specPolicy === 'DEFINE_MANY_MERGED') ?  false ? invariant(false, 'ReactClassInterface: You are attempting to define `%s` on your component more than once. This conflict may be due to a mixin.', name) : _prodInvariant('74', name) : void 0;
 	  }
 	}
 
@@ -2420,13 +2400,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	          var specPolicy = ReactClassInterface[name];
 
 	          // These cases should already be caught by validateMethodOverride.
-	          !(isReactClassMethod && (specPolicy === SpecPolicy.DEFINE_MANY_MERGED || specPolicy === SpecPolicy.DEFINE_MANY)) ?  false ? invariant(false, 'ReactClass: Unexpected spec policy %s for key %s when mixing in component specs.', specPolicy, name) : _prodInvariant('77', specPolicy, name) : void 0;
+	          !(isReactClassMethod && (specPolicy === 'DEFINE_MANY_MERGED' || specPolicy === 'DEFINE_MANY')) ?  false ? invariant(false, 'ReactClass: Unexpected spec policy %s for key %s when mixing in component specs.', specPolicy, name) : _prodInvariant('77', specPolicy, name) : void 0;
 
 	          // For methods which are defined more than once, call the existing
 	          // methods before calling the new property, merging if appropriate.
-	          if (specPolicy === SpecPolicy.DEFINE_MANY_MERGED) {
+	          if (specPolicy === 'DEFINE_MANY_MERGED') {
 	            proto[name] = createMergedResultFunction(proto[name], property);
-	          } else if (specPolicy === SpecPolicy.DEFINE_MANY) {
+	          } else if (specPolicy === 'DEFINE_MANY') {
 	            proto[name] = createChainedFunction(proto[name], property);
 	          }
 	        } else {
@@ -2621,7 +2601,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @public
 	   */
 	  createClass: function createClass(spec) {
-	    var Constructor = function Constructor(props, context, updater) {
+	    // To keep our warnings more understandable, we'll use a little hack here to
+	    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+	    // unnecessarily identify a class without displayName as 'Constructor'.
+	    var Constructor = identity(function (props, context, updater) {
 	      // This constructor gets overridden by mocks. The argument is used
 	      // by mocks to assert on what gets mounted.
 
@@ -2656,7 +2639,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      !((typeof initialState === 'undefined' ? 'undefined' : _typeof(initialState)) === 'object' && !Array.isArray(initialState)) ?  false ? invariant(false, '%s.getInitialState(): must return an object or null', Constructor.displayName || 'ReactCompositeComponent') : _prodInvariant('82', Constructor.displayName || 'ReactCompositeComponent') : void 0;
 
 	      this.state = initialState;
-	    };
+	    });
 	    Constructor.prototype = new ReactClassComponent();
 	    Constructor.prototype.constructor = Constructor;
 	    Constructor.prototype.__reactAutoBindPairs = [];
@@ -2711,89 +2694,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactClass;
 
 /***/ },
-/* 22 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule ReactPropTypeLocations
-	 */
-
-	'use strict';
-
-	var keyMirror = __webpack_require__(23);
-
-	var ReactPropTypeLocations = keyMirror({
-	  prop: null,
-	  context: null,
-	  childContext: null
-	});
-
-	module.exports = ReactPropTypeLocations;
-
-/***/ },
 /* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @typechecks static-only
-	 */
-
-	'use strict';
-
-	var invariant = __webpack_require__(8);
-
-	/**
-	 * Constructs an enumeration with keys equal to their value.
-	 *
-	 * For example:
-	 *
-	 *   var COLORS = keyMirror({blue: null, red: null});
-	 *   var myColor = COLORS.blue;
-	 *   var isColorValid = !!COLORS[myColor];
-	 *
-	 * The last line could not be performed if the values of the generated enum were
-	 * not equal to their keys.
-	 *
-	 *   Input:  {key1: val1, key2: val2}
-	 *   Output: {key1: key1, key2: key2}
-	 *
-	 * @param {object} obj
-	 * @return {object}
-	 */
-	var keyMirror = function keyMirror(obj) {
-	  var ret = {};
-	  var key;
-	  !(obj instanceof Object && !Array.isArray(obj)) ?  false ? invariant(false, 'keyMirror(...): Argument must be an object.') : invariant(false) : void 0;
-	  for (key in obj) {
-	    if (!obj.hasOwnProperty(key)) {
-	      continue;
-	    }
-	    ret[key] = key;
-	  }
-	  return ret;
-	};
-
-	module.exports = keyMirror;
-
-/***/ },
-/* 24 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
 	 * Copyright 2013-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
@@ -2801,7 +2705,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypeLocationNames
+	 * 
 	 */
 
 	'use strict';
@@ -2819,47 +2723,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypeLocationNames;
 
 /***/ },
-/* 25 */
-/***/ function(module, exports) {
-
-	"use strict";
-
-	/**
-	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	/**
-	 * Allows extraction of a minified key. Let's the build system minify keys
-	 * without losing the ability to dynamically use key strings as values
-	 * themselves. Pass in an object with a single key/val pair and it will return
-	 * you the string key of that single record. Suppose you want to grab the
-	 * value for a key 'className' inside of an object. Key/val minification may
-	 * have aliased that key to be 'xa12'. keyOf({className: null}) will return
-	 * 'xa12' in that case. Resolve keys you want to use once at startup time, then
-	 * reuse those resolutions.
-	 */
-
-	var keyOf = function keyOf(oneKeyObj) {
-	  var key;
-	  for (key in oneKeyObj) {
-	    if (!oneKeyObj.hasOwnProperty(key)) {
-	      continue;
-	    }
-	    return key;
-	  }
-	  return null;
-	};
-
-	module.exports = keyOf;
-
-/***/ },
-/* 26 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -2870,7 +2734,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMFactories
 	 */
 
 	'use strict';
@@ -3034,7 +2897,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMFactories;
 
 /***/ },
-/* 27 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -3045,7 +2908,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypes
 	 */
 
 	'use strict';
@@ -3053,11 +2915,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 	var ReactElement = __webpack_require__(9);
-	var ReactPropTypeLocationNames = __webpack_require__(24);
-	var ReactPropTypesSecret = __webpack_require__(28);
+	var ReactPropTypeLocationNames = __webpack_require__(23);
+	var ReactPropTypesSecret = __webpack_require__(26);
 
 	var emptyFunction = __webpack_require__(12);
-	var getIteratorFn = __webpack_require__(15);
+	var getIteratorFn = __webpack_require__(16);
 	var warning = __webpack_require__(11);
 
 	/**
@@ -3172,7 +3034,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (secret !== ReactPropTypesSecret && typeof console !== 'undefined') {
 	        var cacheKey = componentName + ':' + propName;
 	        if (!manualPropTypeCallCache[cacheKey]) {
-	          process.env.NODE_ENV !== 'production' ? warning(false, 'You are manually calling a React.PropTypes validation ' + 'function for the `%s` prop on `%s`. This is deprecated ' + 'and will not work in the next major version. You may be ' + 'seeing this warning due to a third-party PropTypes library. ' + 'See https://fb.me/react-warning-dont-call-proptypes for details.', propFullName, componentName) : void 0;
+	          process.env.NODE_ENV !== 'production' ? warning(false, 'You are manually calling a React.PropTypes validation ' + 'function for the `%s` prop on `%s`. This is deprecated ' + 'and will not work in production with the next major version. ' + 'You may be seeing this warning due to a third-party PropTypes ' + 'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.', propFullName, componentName) : void 0;
 	          manualPropTypeCallCache[cacheKey] = true;
 	        }
 	      }
@@ -3180,7 +3042,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (props[propName] == null) {
 	      var locationName = ReactPropTypeLocationNames[location];
 	      if (isRequired) {
-	        return new PropTypeError('Required ' + locationName + ' `' + propFullName + '` was not specified in ' + ('`' + componentName + '`.'));
+	        if (props[propName] === null) {
+	          return new PropTypeError('The ' + locationName + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+	        }
+	        return new PropTypeError('The ' + locationName + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
 	      }
 	      return null;
 	    } else {
@@ -3472,7 +3337,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypes;
 
 /***/ },
-/* 28 */
+/* 26 */
 /***/ function(module, exports) {
 
 	/**
@@ -3483,7 +3348,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactPropTypesSecret
+	 * 
 	 */
 
 	'use strict';
@@ -3493,7 +3358,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactPropTypesSecret;
 
 /***/ },
-/* 29 */
+/* 27 */
 /***/ function(module, exports) {
 
 	/**
@@ -3504,15 +3369,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactVersion
 	 */
 
 	'use strict';
 
-	module.exports = '15.3.2';
+	module.exports = '15.4.1';
 
 /***/ },
-/* 30 */
+/* 28 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -3523,7 +3387,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule onlyChild
 	 */
 	'use strict';
 
@@ -3555,14 +3418,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = onlyChild;
 
 /***/ },
-/* 31 */
+/* 29 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-ease/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-ease/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
@@ -3636,6 +3499,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var pi = Math.PI;
 	  var halfPi = pi / 2;
+
 	  function sinIn(t) {
 	    return 1 - Math.cos(t * halfPi);
 	  }
@@ -3682,6 +3546,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var b8 = 21 / 22;
 	  var b9 = 63 / 64;
 	  var b0 = 1 / b1 / b1;
+
 	  function bounceIn(t) {
 	    return 1 - bounceOut(1 - t);
 	  }
@@ -3735,6 +3600,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var tau = 2 * Math.PI;
 	  var amplitude = 1;
 	  var period = 0.3;
+
 	  var elasticIn = function custom(a, p) {
 	    var s = Math.asin(1 / (a = Math.max(1, a))) * (p /= tau);
 
@@ -3828,16 +3694,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 32 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-interpolate/ Version 1.1.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-interpolate/ Version 1.1.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(33)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(31)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
 	})(undefined, function (exports, d3Color) {
 	  'use strict';
 
@@ -3847,7 +3713,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return ((1 - 3 * t1 + 3 * t2 - t3) * v0 + (4 - 6 * t2 + 3 * t3) * v1 + (1 + 3 * t1 + 3 * t2 - 3 * t3) * v2 + t3 * v3) / 6;
 	  }
 
-	  function basis$1(values) {
+	  var basis$1 = function basis$1(values) {
 	    var n = values.length - 1;
 	    return function (t) {
 	      var i = t <= 0 ? t = 0 : t >= 1 ? (t = 1, n - 1) : Math.floor(t * n),
@@ -3857,9 +3723,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	          v3 = i < n - 1 ? values[i + 2] : 2 * v2 - v1;
 	      return basis((t - i / n) * n, v0, v1, v2, v3);
 	    };
-	  }
+	  };
 
-	  function basisClosed(values) {
+	  var basisClosed = function basisClosed(values) {
 	    var n = values.length;
 	    return function (t) {
 	      var i = Math.floor(((t %= 1) < 0 ? ++t : t) * n),
@@ -3869,13 +3735,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	          v3 = values[(i + 2) % n];
 	      return basis((t - i / n) * n, v0, v1, v2, v3);
 	    };
-	  }
+	  };
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
 	  function linear(a, d) {
 	    return function (t) {
@@ -3906,13 +3772,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  var rgb$1 = function rgbGamma(y) {
-	    var color = gamma(y);
+	    var color$$1 = gamma(y);
 
-	    function rgb(start, end) {
-	      var r = color((start = d3Color.rgb(start)).r, (end = d3Color.rgb(end)).r),
-	          g = color(start.g, end.g),
-	          b = color(start.b, end.b),
-	          opacity = color(start.opacity, end.opacity);
+	    function rgb$$1(start, end) {
+	      var r = color$$1((start = d3Color.rgb(start)).r, (end = d3Color.rgb(end)).r),
+	          g = color$$1(start.g, end.g),
+	          b = color$$1(start.b, end.b),
+	          opacity = color$$1(start.opacity, end.opacity);
 	      return function (t) {
 	        start.r = r(t);
 	        start.g = g(t);
@@ -3922,9 +3788,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      };
 	    }
 
-	    rgb.gamma = rgbGamma;
+	    rgb$$1.gamma = rgbGamma;
 
-	    return rgb;
+	    return rgb$$1;
 	  }(1);
 
 	  function rgbSpline(spline) {
@@ -3934,22 +3800,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	          g = new Array(n),
 	          b = new Array(n),
 	          i,
-	          color;
+	          color$$1;
 	      for (i = 0; i < n; ++i) {
-	        color = d3Color.rgb(colors[i]);
-	        r[i] = color.r || 0;
-	        g[i] = color.g || 0;
-	        b[i] = color.b || 0;
+	        color$$1 = d3Color.rgb(colors[i]);
+	        r[i] = color$$1.r || 0;
+	        g[i] = color$$1.g || 0;
+	        b[i] = color$$1.b || 0;
 	      }
 	      r = spline(r);
 	      g = spline(g);
 	      b = spline(b);
-	      color.opacity = 1;
+	      color$$1.opacity = 1;
 	      return function (t) {
-	        color.r = r(t);
-	        color.g = g(t);
-	        color.b = b(t);
-	        return color + "";
+	        color$$1.r = r(t);
+	        color$$1.g = g(t);
+	        color$$1.b = b(t);
+	        return color$$1 + "";
 	      };
 	    };
 	  }
@@ -3957,7 +3823,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var rgbBasis = rgbSpline(basis$1);
 	  var rgbBasisClosed = rgbSpline(basisClosed);
 
-	  function array(a, b) {
+	  var array = function array(a, b) {
 	    var nb = b ? b.length : 0,
 	        na = a ? Math.min(nb, a.length) : 0,
 	        x = new Array(nb),
@@ -3973,22 +3839,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	        c[i] = x[i](t);
 	      }return c;
 	    };
-	  }
+	  };
 
-	  function date(a, b) {
+	  var date = function date(a, b) {
 	    var d = new Date();
 	    return a = +a, b -= a, function (t) {
 	      return d.setTime(a + b * t), d;
 	    };
-	  }
+	  };
 
-	  function number(a, b) {
+	  var number = function number(a, b) {
 	    return a = +a, b -= a, function (t) {
 	      return a + b * t;
 	    };
-	  }
+	  };
 
-	  function object(a, b) {
+	  var object = function object(a, b) {
 	    var i = {},
 	        c = {},
 	        k;
@@ -4009,10 +3875,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	        c[k] = i[k](t);
 	      }return c;
 	    };
-	  }
+	  };
 
 	  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g;
 	  var reB = new RegExp(reA.source, "g");
+
 	  function zero(b) {
 	    return function () {
 	      return b;
@@ -4025,7 +3892,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function string(a, b) {
+	  var string = function string(a, b) {
 	    var bi = reA.lastIndex = reB.lastIndex = 0,
 	        // scan index for next number in b
 	    am,
@@ -4077,19 +3944,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	        s[(o = q[i]).i] = o.x(t);
 	      }return s.join("");
 	    });
-	  }
+	  };
 
-	  function value(a, b) {
+	  var value = function value(a, b) {
 	    var t = typeof b === 'undefined' ? 'undefined' : _typeof(b),
 	        c;
 	    return b == null || t === "boolean" ? constant(b) : (t === "number" ? number : t === "string" ? (c = d3Color.color(b)) ? (b = c, rgb$1) : string : b instanceof d3Color.color ? rgb$1 : b instanceof Date ? date : Array.isArray(b) ? array : isNaN(b) ? object : number)(a, b);
-	  }
+	  };
 
-	  function round(a, b) {
+	  var round = function round(a, b) {
 	    return a = +a, b -= a, function (t) {
 	      return Math.round(a + b * t);
 	    };
-	  }
+	  };
 
 	  var degrees = 180 / Math.PI;
 
@@ -4102,7 +3969,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    scaleY: 1
 	  };
 
-	  function decompose(a, b, c, d, e, f) {
+	  var decompose = function decompose(a, b, c, d, e, f) {
 	    var scaleX, scaleY, skewX;
 	    if (scaleX = Math.sqrt(a * a + b * b)) a /= scaleX, b /= scaleX;
 	    if (skewX = a * c + b * d) c -= a * skewX, d -= b * skewX;
@@ -4116,12 +3983,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scaleX: scaleX,
 	      scaleY: scaleY
 	    };
-	  }
+	  };
 
 	  var cssNode;
 	  var cssRoot;
 	  var cssView;
 	  var svgNode;
+
 	  function parseCss(value) {
 	    if (value === "none") return identity;
 	    if (!cssNode) cssNode = document.createElement("DIV"), cssRoot = document.documentElement, cssView = document.defaultView;
@@ -4210,6 +4078,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var rho2 = 2;
 	  var rho4 = 4;
 	  var epsilon2 = 1e-12;
+
 	  function cosh(x) {
 	    return ((x = Math.exp(x)) + 1 / x) / 2;
 	  }
@@ -4224,7 +4093,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // p0 = [ux0, uy0, w0]
 	  // p1 = [ux1, uy1, w1]
-	  function zoom(p0, p1) {
+	  var zoom = function zoom(p0, p1) {
 	    var ux0 = p0[0],
 	        uy0 = p0[1],
 	        w0 = p0[2],
@@ -4264,11 +4133,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    i.duration = S * 1000;
 
 	    return i;
-	  }
+	  };
 
-	  function hsl$1(hue) {
+	  function hsl$1(hue$$1) {
 	    return function (start, end) {
-	      var h = hue((start = d3Color.hsl(start)).h, (end = d3Color.hsl(end)).h),
+	      var h = hue$$1((start = d3Color.hsl(start)).h, (end = d3Color.hsl(end)).h),
 	          s = nogamma(start.s, end.s),
 	          l = nogamma(start.l, end.l),
 	          opacity = nogamma(start.opacity, end.opacity);
@@ -4299,9 +4168,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function hcl$1(hue) {
+	  function hcl$1(hue$$1) {
 	    return function (start, end) {
-	      var h = hue((start = d3Color.hcl(start)).h, (end = d3Color.hcl(end)).h),
+	      var h = hue$$1((start = d3Color.hcl(start)).h, (end = d3Color.hcl(end)).h),
 	          c = nogamma(start.c, end.c),
 	          l = nogamma(start.l, end.l),
 	          opacity = nogamma(start.opacity, end.opacity);
@@ -4318,12 +4187,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var hcl$2 = hcl$1(hue);
 	  var hclLong = hcl$1(nogamma);
 
-	  function cubehelix$1(hue) {
+	  function cubehelix$1(hue$$1) {
 	    return function cubehelixGamma(y) {
 	      y = +y;
 
-	      function cubehelix(start, end) {
-	        var h = hue((start = d3Color.cubehelix(start)).h, (end = d3Color.cubehelix(end)).h),
+	      function cubehelix$$1(start, end) {
+	        var h = hue$$1((start = d3Color.cubehelix(start)).h, (end = d3Color.cubehelix(end)).h),
 	            s = nogamma(start.s, end.s),
 	            l = nogamma(start.l, end.l),
 	            opacity = nogamma(start.opacity, end.opacity);
@@ -4336,21 +4205,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	        };
 	      }
 
-	      cubehelix.gamma = cubehelixGamma;
+	      cubehelix$$1.gamma = cubehelixGamma;
 
-	      return cubehelix;
+	      return cubehelix$$1;
 	    }(1);
 	  }
 
 	  var cubehelix$2 = cubehelix$1(hue);
 	  var cubehelixLong = cubehelix$1(nogamma);
 
-	  function quantize(interpolator, n) {
+	  var quantize = function quantize(interpolator, n) {
 	    var samples = new Array(n);
 	    for (var i = 0; i < n; ++i) {
 	      samples[i] = interpolator(i / (n - 1));
 	    }return samples;
-	  }
+	  };
 
 	  exports.interpolate = value;
 	  exports.interpolateArray = array;
@@ -4380,23 +4249,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 33 */
+/* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-color/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-color/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
 	  'use strict';
 
-	  function define(constructor, factory, prototype) {
+	  var define = function define(constructor, factory, prototype) {
 	    constructor.prototype = factory.prototype = prototype;
 	    prototype.constructor = constructor;
-	  }
+	  };
 
 	  function extend(parent, definition) {
 	    var prototype = Object.create(parent.prototype);
@@ -4410,14 +4279,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var _darker = 0.7;
 	  var _brighter = 1 / _darker;
 
+	  var reI = "\\s*([+-]?\\d+)\\s*";
+	  var reN = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)\\s*";
+	  var reP = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)%\\s*";
 	  var reHex3 = /^#([0-9a-f]{3})$/;
 	  var reHex6 = /^#([0-9a-f]{6})$/;
-	  var reRgbInteger = /^rgb\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*\)$/;
-	  var reRgbPercent = /^rgb\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/;
-	  var reRgbaInteger = /^rgba\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
-	  var reRgbaPercent = /^rgba\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
-	  var reHslPercent = /^hsl\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/;
-	  var reHslaPercent = /^hsla\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/;
+	  var reRgbInteger = new RegExp("^rgb\\(" + [reI, reI, reI] + "\\)$");
+	  var reRgbPercent = new RegExp("^rgb\\(" + [reP, reP, reP] + "\\)$");
+	  var reRgbaInteger = new RegExp("^rgba\\(" + [reI, reI, reI, reN] + "\\)$");
+	  var reRgbaPercent = new RegExp("^rgba\\(" + [reP, reP, reP, reN] + "\\)$");
+	  var reHslPercent = new RegExp("^hsl\\(" + [reN, reP, reP] + "\\)$");
+	  var reHslaPercent = new RegExp("^hsla\\(" + [reN, reP, reP, reN] + "\\)$");
+
 	  var named = {
 	    aliceblue: 0xf0f8ff,
 	    antiquewhite: 0xfaebd7,
@@ -4718,6 +4591,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var t1 = 6 / 29;
 	  var t2 = 3 * t1 * t1;
 	  var t3 = t1 * t1 * t1;
+
 	  function labConvert(o) {
 	    if (o instanceof Lab) return new Lab(o.l, o.a, o.b, o.opacity);
 	    if (o instanceof Hcl) {
@@ -4818,6 +4692,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var ED = E * D;
 	  var EB = E * B;
 	  var BC_DA = B * C - D * A;
+
 	  function cubehelixConvert(o) {
 	    if (o instanceof Cubehelix) return new Cubehelix(o.h, o.s, o.l, o.opacity);
 	    if (!(o instanceof Rgb)) o = rgbConvert(o);
@@ -4874,7 +4749,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 34 */
+/* 32 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -5034,7 +4909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 35 */
+/* 33 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5048,19 +4923,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationProvider = __webpack_require__(36);
+	var _jubilationProvider = __webpack_require__(34);
 
 	var _jubilationProvider2 = _interopRequireDefault(_jubilationProvider);
 
-	var _jubilationContainer = __webpack_require__(48);
+	var _jubilationContainer = __webpack_require__(46);
 
 	var _jubilationContainer2 = _interopRequireDefault(_jubilationContainer);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _chart = __webpack_require__(49);
+	var _chart = __webpack_require__(47);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5087,7 +4962,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 36 */
+/* 34 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5102,15 +4977,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _jubilationContext = __webpack_require__(40);
+	var _jubilationContext = __webpack_require__(38);
 
 	var _jubilationContext2 = _interopRequireDefault(_jubilationContext);
 
@@ -5182,7 +5057,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationProvider;
 
 /***/ },
-/* 37 */
+/* 35 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5195,7 +5070,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	// Unique ID creation requires a high quality random # generator.  We feature
 	// detect to determine the best RNG source, normalizing to a function that
 	// returns 128-bits of randomness, since that's what's usually required
-	var _rng = __webpack_require__(38);
+	var _rng = __webpack_require__(36);
 
 	// Maps for number <-> hex string conversion
 	var _byteToHex = [];
@@ -5366,7 +5241,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = uuid;
 
 /***/ },
-/* 38 */
+/* 36 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
@@ -5404,7 +5279,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 39 */
+/* 37 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -5447,7 +5322,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = theme;
 
 /***/ },
-/* 40 */
+/* 38 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -5456,9 +5331,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  value: true
 	});
 
-	var _d3Scale = __webpack_require__(41);
+	var _d3Scale = __webpack_require__(39);
 
-	var _provider = __webpack_require__(47);
+	var _provider = __webpack_require__(45);
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -5510,16 +5385,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationContext;
 
 /***/ },
-/* 41 */
+/* 39 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-scale/ Version 1.0.3. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-scale/ Version 1.0.4. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(42), __webpack_require__(43), __webpack_require__(32), __webpack_require__(44), __webpack_require__(45), __webpack_require__(46), __webpack_require__(33)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(42), __webpack_require__(43), __webpack_require__(32), __webpack_require__(44), __webpack_require__(45), __webpack_require__(46), __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(40), __webpack_require__(41), __webpack_require__(30), __webpack_require__(42), __webpack_require__(43), __webpack_require__(44), __webpack_require__(31)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(40), __webpack_require__(41), __webpack_require__(30), __webpack_require__(42), __webpack_require__(43), __webpack_require__(44), __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3, global.d3);
 	})(undefined, function (exports, d3Array, d3Collection, d3Interpolate, d3Format, d3Time, d3TimeFormat, d3Color) {
 	  'use strict';
 
@@ -5530,12 +5405,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var implicit = { name: "implicit" };
 
-	  function ordinal(range) {
+	  function ordinal(range$$1) {
 	    var index = d3Collection.map(),
 	        domain = [],
 	        unknown = implicit;
 
-	    range = range == null ? [] : slice.call(range);
+	    range$$1 = range$$1 == null ? [] : slice.call(range$$1);
 
 	    function scale(d) {
 	      var key = d + "",
@@ -5544,7 +5419,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (unknown !== implicit) return unknown;
 	        index.set(key, i = domain.push(d));
 	      }
-	      return range[(i - 1) % range.length];
+	      return range$$1[(i - 1) % range$$1.length];
 	    }
 
 	    scale.domain = function (_) {
@@ -5560,7 +5435,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), scale) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), scale) : range$$1.slice();
 	    };
 
 	    scale.unknown = function (_) {
@@ -5568,7 +5443,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return ordinal().domain(domain).range(range).unknown(unknown);
+	      return ordinal().domain(domain).range(range$$1).unknown(unknown);
 	    };
 
 	    return scale;
@@ -5578,7 +5453,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var scale = ordinal().unknown(undefined),
 	        domain = scale.domain,
 	        ordinalRange = scale.range,
-	        range = [0, 1],
+	        range$$1 = [0, 1],
 	        step,
 	        bandwidth,
 	        round = false,
@@ -5590,9 +5465,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    function rescale() {
 	      var n = domain().length,
-	          reverse = range[1] < range[0],
-	          start = range[reverse - 0],
-	          stop = range[1 - reverse];
+	          reverse = range$$1[1] < range$$1[0],
+	          start = range$$1[reverse - 0],
+	          stop = range$$1[1 - reverse];
 	      step = (stop - start) / Math.max(1, n - paddingInner + paddingOuter * 2);
 	      if (round) step = Math.floor(step);
 	      start += (stop - start - step * (n - paddingInner)) * align;
@@ -5609,11 +5484,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = [+_[0], +_[1]], rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = [+_[0], +_[1]], rescale()) : range$$1.slice();
 	    };
 
 	    scale.rangeRound = function (_) {
-	      return range = [+_[0], +_[1]], round = true, rescale();
+	      return range$$1 = [+_[0], +_[1]], round = true, rescale();
 	    };
 
 	    scale.bandwidth = function () {
@@ -5645,7 +5520,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return band().domain(domain()).range(range).round(round).paddingInner(paddingInner).paddingOuter(paddingOuter).align(align);
+	      return band().domain(domain()).range(range$$1).round(round).paddingInner(paddingInner).paddingOuter(paddingOuter).align(align);
 	    };
 
 	    return rescale();
@@ -5669,19 +5544,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return pointish(band().paddingInner(1));
 	  }
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
-	  function number(x) {
+	  var number = function number(x) {
 	    return +x;
-	  }
+	  };
 
 	  var unit = [0, 1];
 
-	  function deinterpolate(a, b) {
+	  function deinterpolateLinear(a, b) {
 	    return (b -= a = +a) ? function (x) {
 	      return (x - a) / b;
 	    } : constant(b);
@@ -5705,19 +5580,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 
-	  function bimap(domain, range, deinterpolate, reinterpolate) {
+	  function bimap(domain, range$$1, deinterpolate, reinterpolate) {
 	    var d0 = domain[0],
 	        d1 = domain[1],
-	        r0 = range[0],
-	        r1 = range[1];
+	        r0 = range$$1[0],
+	        r1 = range$$1[1];
 	    if (d1 < d0) d0 = deinterpolate(d1, d0), r0 = reinterpolate(r1, r0);else d0 = deinterpolate(d0, d1), r0 = reinterpolate(r0, r1);
 	    return function (x) {
 	      return r0(d0(x));
 	    };
 	  }
 
-	  function polymap(domain, range, deinterpolate, reinterpolate) {
-	    var j = Math.min(domain.length, range.length) - 1,
+	  function polymap(domain, range$$1, deinterpolate, reinterpolate) {
+	    var j = Math.min(domain.length, range$$1.length) - 1,
 	        d = new Array(j),
 	        r = new Array(j),
 	        i = -1;
@@ -5725,12 +5600,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // Reverse descending domains.
 	    if (domain[j] < domain[0]) {
 	      domain = domain.slice().reverse();
-	      range = range.slice().reverse();
+	      range$$1 = range$$1.slice().reverse();
 	    }
 
 	    while (++i < j) {
 	      d[i] = deinterpolate(domain[i], domain[i + 1]);
-	      r[i] = reinterpolate(range[i], range[i + 1]);
+	      r[i] = reinterpolate(range$$1[i], range$$1[i + 1]);
 	    }
 
 	    return function (x) {
@@ -5745,27 +5620,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // deinterpolate(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
 	  // reinterpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding domain value x in [a,b].
-	  function continuous(deinterpolate$$, reinterpolate) {
+	  function continuous(deinterpolate, reinterpolate) {
 	    var domain = unit,
-	        range = unit,
-	        interpolate = d3Interpolate.interpolate,
+	        range$$1 = unit,
+	        interpolate$$1 = d3Interpolate.interpolate,
 	        clamp = false,
 	        piecewise,
 	        output,
 	        input;
 
 	    function rescale() {
-	      piecewise = Math.min(domain.length, range.length) > 2 ? polymap : bimap;
+	      piecewise = Math.min(domain.length, range$$1.length) > 2 ? polymap : bimap;
 	      output = input = null;
 	      return scale;
 	    }
 
 	    function scale(x) {
-	      return (output || (output = piecewise(domain, range, clamp ? deinterpolateClamp(deinterpolate$$) : deinterpolate$$, interpolate)))(+x);
+	      return (output || (output = piecewise(domain, range$$1, clamp ? deinterpolateClamp(deinterpolate) : deinterpolate, interpolate$$1)))(+x);
 	    }
 
 	    scale.invert = function (y) {
-	      return (input || (input = piecewise(range, domain, deinterpolate, clamp ? reinterpolateClamp(reinterpolate) : reinterpolate)))(+y);
+	      return (input || (input = piecewise(range$$1, domain, deinterpolateLinear, clamp ? reinterpolateClamp(reinterpolate) : reinterpolate)))(+y);
 	    };
 
 	    scale.domain = function (_) {
@@ -5773,11 +5648,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), rescale()) : range$$1.slice();
 	    };
 
 	    scale.rangeRound = function (_) {
-	      return range = slice.call(_), interpolate = d3Interpolate.interpolateRound, rescale();
+	      return range$$1 = slice.call(_), interpolate$$1 = d3Interpolate.interpolateRound, rescale();
 	    };
 
 	    scale.clamp = function (_) {
@@ -5785,13 +5660,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.interpolate = function (_) {
-	      return arguments.length ? (interpolate = _, rescale()) : interpolate;
+	      return arguments.length ? (interpolate$$1 = _, rescale()) : interpolate$$1;
 	    };
 
 	    return rescale();
 	  }
 
-	  function tickFormat(domain, count, specifier) {
+	  var tickFormat = function tickFormat(domain, count, specifier) {
 	    var start = domain[0],
 	        stop = domain[domain.length - 1],
 	        step = d3Array.tickStep(start, stop, count == null ? 10 : count),
@@ -5821,7 +5696,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	    }
 	    return d3Format.format(specifier);
-	  }
+	  };
 
 	  function linearish(scale) {
 	    var domain = scale.domain;
@@ -5857,7 +5732,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  function linear() {
-	    var scale = continuous(deinterpolate, d3Interpolate.interpolateNumber);
+	    var scale = continuous(deinterpolateLinear, d3Interpolate.interpolateNumber);
 
 	    scale.copy = function () {
 	      return copy(scale, linear());
@@ -5886,7 +5761,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return linearish(scale);
 	  }
 
-	  function nice(domain, interval) {
+	  var nice = function nice(domain, interval) {
 	    domain = domain.slice();
 
 	    var i0 = 0,
@@ -5903,9 +5778,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    domain[i0] = interval.floor(x0);
 	    domain[i1] = interval.ceil(x1);
 	    return domain;
-	  }
+	  };
 
-	  function deinterpolate$1(a, b) {
+	  function deinterpolate(a, b) {
 	    return (b = Math.log(b / a)) ? function (x) {
 	      return Math.log(x / a) / b;
 	    } : constant(b);
@@ -5942,7 +5817,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  function log() {
-	    var scale = continuous(deinterpolate$1, reinterpolate).domain([1, 10]),
+	    var scale = continuous(deinterpolate, reinterpolate).domain([1, 10]),
 	        domain = scale.domain,
 	        base = 10,
 	        logs = logp(10),
@@ -6072,12 +5947,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  function quantile$1() {
 	    var domain = [],
-	        range = [],
+	        range$$1 = [],
 	        thresholds = [];
 
 	    function rescale() {
 	      var i = 0,
-	          n = Math.max(1, range.length);
+	          n = Math.max(1, range$$1.length);
 	      thresholds = new Array(n - 1);
 	      while (++i < n) {
 	        thresholds[i - 1] = d3Array.quantile(domain, i / n);
@@ -6085,11 +5960,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    function scale(x) {
-	      if (!isNaN(x = +x)) return range[d3Array.bisect(thresholds, x)];
+	      if (!isNaN(x = +x)) return range$$1[d3Array.bisect(thresholds, x)];
 	    }
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return i < 0 ? [NaN, NaN] : [i > 0 ? thresholds[i - 1] : domain[0], i < thresholds.length ? thresholds[i] : domain[domain.length - 1]];
 	    };
 
@@ -6103,7 +5978,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), rescale()) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), rescale()) : range$$1.slice();
 	    };
 
 	    scale.quantiles = function () {
@@ -6111,7 +5986,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return quantile$1().domain(domain).range(range);
+	      return quantile$1().domain(domain).range(range$$1);
 	    };
 
 	    return scale;
@@ -6122,10 +5997,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        x1 = 1,
 	        n = 1,
 	        domain = [0.5],
-	        range = [0, 1];
+	        range$$1 = [0, 1];
 
 	    function scale(x) {
-	      if (x <= x) return range[d3Array.bisect(domain, x, 0, n)];
+	      if (x <= x) return range$$1[d3Array.bisect(domain, x, 0, n)];
 	    }
 
 	    function rescale() {
@@ -6141,16 +6016,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (n = (range = slice.call(_)).length - 1, rescale()) : range.slice();
+	      return arguments.length ? (n = (range$$1 = slice.call(_)).length - 1, rescale()) : range$$1.slice();
 	    };
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return i < 0 ? [NaN, NaN] : i < 1 ? [x0, domain[0]] : i >= n ? [domain[n - 1], x1] : [domain[i - 1], domain[i]];
 	    };
 
 	    scale.copy = function () {
-	      return quantize().domain([x0, x1]).range(range);
+	      return quantize().domain([x0, x1]).range(range$$1);
 	    };
 
 	    return linearish(scale);
@@ -6158,28 +6033,28 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  function threshold() {
 	    var domain = [0.5],
-	        range = [0, 1],
+	        range$$1 = [0, 1],
 	        n = 1;
 
 	    function scale(x) {
-	      if (x <= x) return range[d3Array.bisect(domain, x, 0, n)];
+	      if (x <= x) return range$$1[d3Array.bisect(domain, x, 0, n)];
 	    }
 
 	    scale.domain = function (_) {
-	      return arguments.length ? (domain = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : domain.slice();
+	      return arguments.length ? (domain = slice.call(_), n = Math.min(domain.length, range$$1.length - 1), scale) : domain.slice();
 	    };
 
 	    scale.range = function (_) {
-	      return arguments.length ? (range = slice.call(_), n = Math.min(domain.length, range.length - 1), scale) : range.slice();
+	      return arguments.length ? (range$$1 = slice.call(_), n = Math.min(domain.length, range$$1.length - 1), scale) : range$$1.slice();
 	    };
 
 	    scale.invertExtent = function (y) {
-	      var i = range.indexOf(y);
+	      var i = range$$1.indexOf(y);
 	      return [domain[i - 1], domain[i]];
 	    };
 
 	    scale.copy = function () {
-	      return threshold().domain(domain).range(range);
+	      return threshold().domain(domain).range(range$$1);
 	    };
 
 	    return scale;
@@ -6192,6 +6067,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var durationWeek = durationDay * 7;
 	  var durationMonth = durationDay * 30;
 	  var durationYear = durationDay * 365;
+
 	  function date(t) {
 	    return new Date(t);
 	  }
@@ -6200,19 +6076,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return t instanceof Date ? +t : +new Date(+t);
 	  }
 
-	  function calendar(year, month, week, day, hour, minute, second, millisecond, format) {
-	    var scale = continuous(deinterpolate, d3Interpolate.interpolateNumber),
+	  function calendar(year, month, week, day, hour, minute, second, millisecond, format$$1) {
+	    var scale = continuous(deinterpolateLinear, d3Interpolate.interpolateNumber),
 	        invert = scale.invert,
 	        domain = scale.domain;
 
-	    var formatMillisecond = format(".%L"),
-	        formatSecond = format(":%S"),
-	        formatMinute = format("%I:%M"),
-	        formatHour = format("%I %p"),
-	        formatDay = format("%a %d"),
-	        formatWeek = format("%b %d"),
-	        formatMonth = format("%B"),
-	        formatYear = format("%Y");
+	    var formatMillisecond = format$$1(".%L"),
+	        formatSecond = format$$1(":%S"),
+	        formatMinute = format$$1("%I:%M"),
+	        formatHour = format$$1("%I %p"),
+	        formatDay = format$$1("%a %d"),
+	        formatWeek = format$$1("%b %d"),
+	        formatMonth = format$$1("%B"),
+	        formatYear = format$$1("%Y");
 
 	    var tickIntervals = [[second, 1, durationSecond], [second, 5, 5 * durationSecond], [second, 15, 15 * durationSecond], [second, 30, 30 * durationSecond], [minute, 1, durationMinute], [minute, 5, 5 * durationMinute], [minute, 15, 15 * durationMinute], [minute, 30, 30 * durationMinute], [hour, 1, durationHour], [hour, 3, 3 * durationHour], [hour, 6, 6 * durationHour], [hour, 12, 12 * durationHour], [day, 1, durationDay], [day, 2, 2 * durationDay], [week, 1, durationWeek], [month, 1, durationMonth], [month, 3, 3 * durationMonth], [year, 1, durationYear]];
 
@@ -6268,7 +6144,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.tickFormat = function (count, specifier) {
-	      return specifier == null ? tickFormat : format(specifier);
+	      return specifier == null ? tickFormat : format$$1(specifier);
 	    };
 
 	    scale.nice = function (interval, step) {
@@ -6277,25 +6153,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    scale.copy = function () {
-	      return copy(scale, calendar(year, month, week, day, hour, minute, second, millisecond, format));
+	      return copy(scale, calendar(year, month, week, day, hour, minute, second, millisecond, format$$1));
 	    };
 
 	    return scale;
 	  }
 
-	  function time() {
+	  var time = function time() {
 	    return calendar(d3Time.timeYear, d3Time.timeMonth, d3Time.timeWeek, d3Time.timeDay, d3Time.timeHour, d3Time.timeMinute, d3Time.timeSecond, d3Time.timeMillisecond, d3TimeFormat.timeFormat).domain([new Date(2000, 0, 1), new Date(2000, 0, 2)]);
-	  }
+	  };
 
-	  function utcTime() {
+	  var utcTime = function utcTime() {
 	    return calendar(d3Time.utcYear, d3Time.utcMonth, d3Time.utcWeek, d3Time.utcDay, d3Time.utcHour, d3Time.utcMinute, d3Time.utcSecond, d3Time.utcMillisecond, d3TimeFormat.utcFormat).domain([Date.UTC(2000, 0, 1), Date.UTC(2000, 0, 2)]);
-	  }
+	  };
 
-	  function colors(s) {
+	  var colors = function colors(s) {
 	    return s.match(/.{6}/g).map(function (x) {
 	      return "#" + x;
 	    });
-	  }
+	  };
 
 	  var category10 = colors("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
 
@@ -6313,19 +6189,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var rainbow = d3Color.cubehelix();
 
-	  function rainbow$1(t) {
+	  var rainbow$1 = function rainbow$1(t) {
 	    if (t < 0 || t > 1) t -= Math.floor(t);
 	    var ts = Math.abs(t - 0.5);
 	    rainbow.h = 360 * t - 100;
 	    rainbow.s = 1.5 - 1.5 * ts;
 	    rainbow.l = 0.8 - 0.9 * ts;
 	    return rainbow + "";
-	  }
+	  };
 
-	  function ramp(range) {
-	    var n = range.length;
+	  function ramp(range$$1) {
+	    var n = range$$1.length;
 	    return function (t) {
-	      return range[Math.max(0, Math.min(n - 1, Math.floor(t * n)))];
+	      return range$$1[Math.max(0, Math.min(n - 1, Math.floor(t * n)))];
 	    };
 	  }
 
@@ -6398,24 +6274,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 42 */
+/* 40 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-array/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-array/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
 	  'use strict';
 
-	  function ascending(a, b) {
+	  var ascending = function ascending(a, b) {
 	    return a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
-	  }
+	  };
 
-	  function bisector(compare) {
+	  var bisector = function bisector(compare) {
 	    if (compare.length === 1) compare = ascendingComparator(compare);
 	    return {
 	      left: function left(a, x, lo, hi) {
@@ -6437,7 +6313,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return lo;
 	      }
 	    };
-	  }
+	  };
 
 	  function ascendingComparator(f) {
 	    return function (d, x) {
@@ -6449,15 +6325,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var bisectRight = ascendingBisect.right;
 	  var bisectLeft = ascendingBisect.left;
 
-	  function descending(a, b) {
+	  var descending = function descending(a, b) {
 	    return b < a ? -1 : b > a ? 1 : b >= a ? 0 : NaN;
-	  }
+	  };
 
-	  function number(x) {
+	  var number = function number(x) {
 	    return x === null ? NaN : +x;
-	  }
+	  };
 
-	  function variance(array, f) {
+	  var variance = function variance(array, f) {
 	    var n = array.length,
 	        m = 0,
 	        a,
@@ -6485,14 +6361,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    if (j > 1) return s / (j - 1);
-	  }
+	  };
 
-	  function deviation(array, f) {
+	  var deviation = function deviation(array, f) {
 	    var v = variance(array, f);
 	    return v ? Math.sqrt(v) : v;
-	  }
+	  };
 
-	  function extent(array, f) {
+	  var extent = function extent(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6524,24 +6400,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return [a, c];
-	  }
+	  };
 
 	  var array = Array.prototype;
 
 	  var slice = array.slice;
 	  var map = array.map;
 
-	  function constant(x) {
+	  var constant = function constant(x) {
 	    return function () {
 	      return x;
 	    };
-	  }
+	  };
 
-	  function identity(x) {
+	  var identity = function identity(x) {
 	    return x;
-	  }
+	  };
 
-	  function range(start, stop, step) {
+	  var range = function range(start, stop, step) {
 	    start = +start, stop = +stop, step = (n = arguments.length) < 2 ? (stop = start, start = 0, 1) : n < 3 ? 1 : +step;
 
 	    var i = -1,
@@ -6553,16 +6429,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return range;
-	  }
+	  };
 
 	  var e10 = Math.sqrt(50);
 	  var e5 = Math.sqrt(10);
 	  var e2 = Math.sqrt(2);
-	  function ticks(start, stop, count) {
+
+	  var ticks = function ticks(start, stop, count) {
 	    var step = tickStep(start, stop, count);
 	    return range(Math.ceil(start / step) * step, Math.floor(stop / step) * step + step / 2, // inclusive
 	    step);
-	  }
+	  };
 
 	  function tickStep(start, stop, count) {
 	    var step0 = Math.abs(stop - start) / Math.max(0, count),
@@ -6572,11 +6449,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return stop < start ? -step1 : step1;
 	  }
 
-	  function sturges(values) {
+	  var sturges = function sturges(values) {
 	    return Math.ceil(Math.log(values.length) / Math.LN2) + 1;
-	  }
+	  };
 
-	  function histogram() {
+	  var histogram = function histogram() {
 	    var value = identity,
 	        domain = extent,
 	        threshold = sturges;
@@ -6639,9 +6516,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 
 	    return histogram;
-	  }
+	  };
 
-	  function quantile(array, p, f) {
+	  var quantile = function quantile(array, p, f) {
 	    if (f == null) f = number;
 	    if (!(n = array.length)) return;
 	    if ((p = +p) <= 0 || n < 2) return +f(array[0], 0, array);
@@ -6652,18 +6529,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	        a = +f(array[i], i, array),
 	        b = +f(array[i + 1], i + 1, array);
 	    return a + (b - a) * (h - i);
-	  }
+	  };
 
-	  function freedmanDiaconis(values, min, max) {
+	  var freedmanDiaconis = function freedmanDiaconis(values, min, max) {
 	    values = map.call(values, number).sort(ascending);
 	    return Math.ceil((max - min) / (2 * (quantile(values, 0.75) - quantile(values, 0.25)) * Math.pow(values.length, -1 / 3)));
-	  }
+	  };
 
-	  function scott(values, min, max) {
+	  var scott = function scott(values, min, max) {
 	    return Math.ceil((max - min) / (3.5 * deviation(values) * Math.pow(values.length, -1 / 3)));
-	  }
+	  };
 
-	  function max(array, f) {
+	  var max = function max(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6688,9 +6565,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return a;
-	  }
+	  };
 
-	  function mean(array, f) {
+	  var mean = function mean(array, f) {
 	    var s = 0,
 	        n = array.length,
 	        a,
@@ -6708,9 +6585,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    if (j) return s / j;
-	  }
+	  };
 
-	  function median(array, f) {
+	  var median = function median(array, f) {
 	    var numbers = [],
 	        n = array.length,
 	        a,
@@ -6727,9 +6604,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return quantile(numbers.sort(ascending), 0.5);
-	  }
+	  };
 
-	  function merge(arrays) {
+	  var merge = function merge(arrays) {
 	    var n = arrays.length,
 	        m,
 	        i = -1,
@@ -6750,9 +6627,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return merged;
-	  }
+	  };
 
-	  function min(array, f) {
+	  var min = function min(array, f) {
 	    var i = -1,
 	        n = array.length,
 	        a,
@@ -6777,9 +6654,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return a;
-	  }
+	  };
 
-	  function pairs(array) {
+	  var pairs = function pairs(array) {
 	    var i = 0,
 	        n = array.length - 1,
 	        p = array[0],
@@ -6787,17 +6664,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    while (i < n) {
 	      pairs[i] = [p, p = array[++i]];
 	    }return pairs;
-	  }
+	  };
 
-	  function permute(array, indexes) {
+	  var permute = function permute(array, indexes) {
 	    var i = indexes.length,
 	        permutes = new Array(i);
 	    while (i--) {
 	      permutes[i] = array[indexes[i]];
 	    }return permutes;
-	  }
+	  };
 
-	  function scan(array, compare) {
+	  var scan = function scan(array, compare) {
 	    if (!(n = array.length)) return;
 	    var i = 0,
 	        n,
@@ -6810,9 +6687,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    while (++i < n) {
 	      if (compare(xi = array[i], xj) < 0 || compare(xj, xj) !== 0) xj = xi, j = i;
 	    }if (compare(xj, xj) === 0) return j;
-	  }
+	  };
 
-	  function shuffle(array, i0, i1) {
+	  var shuffle = function shuffle(array, i0, i1) {
 	    var m = (i1 == null ? array.length : i1) - (i0 = i0 == null ? 0 : +i0),
 	        t,
 	        i;
@@ -6825,9 +6702,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return array;
-	  }
+	  };
 
-	  function sum(array, f) {
+	  var sum = function sum(array, f) {
 	    var s = 0,
 	        n = array.length,
 	        a,
@@ -6844,9 +6721,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    return s;
-	  }
+	  };
 
-	  function transpose(matrix) {
+	  var transpose = function transpose(matrix) {
 	    if (!(n = matrix.length)) return [];
 	    for (var i = -1, m = min(matrix, length), transpose = new Array(m); ++i < m;) {
 	      for (var j = -1, n, row = transpose[i] = new Array(n); ++j < n;) {
@@ -6854,15 +6731,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	    return transpose;
-	  }
+	  };
 
 	  function length(d) {
 	    return d.length;
 	  }
 
-	  function zip() {
+	  var zip = function zip() {
 	    return transpose(arguments);
-	  }
+	  };
 
 	  exports.bisect = bisectRight;
 	  exports.bisectRight = bisectRight;
@@ -6898,14 +6775,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 43 */
+/* 41 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-collection/ Version 1.0.1. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-collection/ Version 1.0.2. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
 	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {});
 	})(undefined, function (exports) {
@@ -6999,7 +6876,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }return map;
 	  }
 
-	  function nest() {
+	  var nest = function nest() {
 	    var keys = [],
 	        _sortKeys = [],
 	        _sortValues,
@@ -7033,11 +6910,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return result;
 	    }
 
-	    function _entries(map, depth) {
-	      if (++depth > keys.length) return map;
+	    function _entries(map$$1, depth) {
+	      if (++depth > keys.length) return map$$1;
 	      var array,
 	          sortKey = _sortKeys[depth - 1];
-	      if (_rollup != null && depth >= keys.length) array = map.entries();else array = [], map.each(function (v, k) {
+	      if (_rollup != null && depth >= keys.length) array = map$$1.entries();else array = [], map$$1.each(function (v, k) {
 	        array.push({ key: k, values: _entries(v, depth) });
 	      });
 	      return sortKey != null ? array.sort(function (a, b) {
@@ -7068,7 +6945,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        _rollup = f;return nest;
 	      }
 	    };
-	  }
+	  };
 
 	  function createObject() {
 	    return {};
@@ -7082,8 +6959,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return map();
 	  }
 
-	  function setMap(map, key, value) {
-	    map.set(key, value);
+	  function setMap(map$$1, key, value) {
+	    map$$1.set(key, value);
 	  }
 
 	  function Set() {}
@@ -7128,26 +7005,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return set;
 	  }
 
-	  function keys(map) {
+	  var keys = function keys(map) {
 	    var keys = [];
 	    for (var key in map) {
 	      keys.push(key);
 	    }return keys;
-	  }
+	  };
 
-	  function values(map) {
+	  var values = function values(map) {
 	    var values = [];
 	    for (var key in map) {
 	      values.push(map[key]);
 	    }return values;
-	  }
+	  };
 
-	  function entries(map) {
+	  var entries = function entries(map) {
 	    var entries = [];
 	    for (var key in map) {
 	      entries.push({ key: key, value: map[key] });
 	    }return entries;
-	  }
+	  };
 
 	  exports.nest = nest;
 	  exports.set = set;
@@ -7160,7 +7037,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 44 */
+/* 42 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -7509,7 +7386,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 45 */
+/* 43 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
@@ -7900,16 +7777,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 46 */
+/* 44 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	// https://d3js.org/d3-time-format/ Version 2.0.2. Copyright 2016 Mike Bostock.
+	// https://d3js.org/d3-time-format/ Version 2.0.3. Copyright 2016 Mike Bostock.
 	(function (global, factory) {
-	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(45)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(45)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
+	  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? factory(exports, __webpack_require__(43)) :  true ? !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(43)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory), __WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? (__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : factory(global.d3 = global.d3 || {}, global.d3);
 	})(undefined, function (exports, d3Time) {
 	  'use strict';
 
@@ -8237,6 +8114,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var numberRe = /^\s*\d+/;
 	  var percentRe = /^%/;
 	  var requoteRe = /[\\\^\$\*\+\?\|\[\]\(\)\.\{\}]/g;
+
 	  function pad(value, fill, width) {
 	    var sign = value < 0 ? "-" : "",
 	        string = (sign ? -value : value) + "",
@@ -8448,7 +8326,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return "%";
 	  }
 
-	  var locale;
+	  var locale$1;
+
 	  defaultLocale({
 	    dateTime: "%x, %X",
 	    date: "%-m/%-d/%Y",
@@ -8461,12 +8340,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	  });
 
 	  function defaultLocale(definition) {
-	    locale = formatLocale(definition);
-	    exports.timeFormat = locale.format;
-	    exports.timeParse = locale.parse;
-	    exports.utcFormat = locale.utcFormat;
-	    exports.utcParse = locale.utcParse;
-	    return locale;
+	    locale$1 = formatLocale(definition);
+	    exports.timeFormat = locale$1.format;
+	    exports.timeParse = locale$1.parse;
+	    exports.utcFormat = locale$1.utcFormat;
+	    exports.utcParse = locale$1.utcParse;
+	    return locale$1;
 	  }
 
 	  var isoSpecifier = "%Y-%m-%dT%H:%M:%S.%LZ";
@@ -8493,7 +8372,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 
 /***/ },
-/* 47 */
+/* 45 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -8559,7 +8438,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 48 */
+/* 46 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8628,7 +8507,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 49 */
+/* 47 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -8656,7 +8535,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 50 */
+/* 48 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8673,7 +8552,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -8737,7 +8616,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationLabel.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 51 */
+/* 49 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8748,7 +8627,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.defaultContext = undefined;
 	exports.default = getContext;
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
@@ -8791,7 +8670,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 52 */
+/* 50 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8805,7 +8684,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -8855,7 +8734,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationPoint.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 53 */
+/* 51 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8872,15 +8751,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationPoint = __webpack_require__(52);
+	var _jubilationPoint = __webpack_require__(50);
 
 	var _jubilationPoint2 = _interopRequireDefault(_jubilationPoint);
 
@@ -8938,7 +8817,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationScatter;
 
 /***/ },
-/* 54 */
+/* 52 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -8975,7 +8854,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 55 */
+/* 53 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -8990,31 +8869,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationRect = __webpack_require__(56);
+	var _jubilationRect = __webpack_require__(54);
 
 	var _jubilationRect2 = _interopRequireDefault(_jubilationRect);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _text = __webpack_require__(58);
+	var _text = __webpack_require__(56);
 
 	var _text2 = _interopRequireDefault(_text);
 
@@ -9158,7 +9037,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationHorizontalBarChart;
 
 /***/ },
-/* 56 */
+/* 54 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9172,7 +9051,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -9229,7 +9108,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationRect.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 57 */
+/* 55 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -9261,7 +9140,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 58 */
+/* 56 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9271,7 +9150,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = getTextWidth;
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
@@ -9294,7 +9173,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 59 */
+/* 57 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9309,27 +9188,27 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _uuid = __webpack_require__(37);
+	var _uuid = __webpack_require__(35);
 
 	var _uuid2 = _interopRequireDefault(_uuid);
 
-	var _scatter = __webpack_require__(54);
+	var _scatter = __webpack_require__(52);
 
 	var _scatter2 = _interopRequireDefault(_scatter);
 
-	var _jubilationRect = __webpack_require__(56);
+	var _jubilationRect = __webpack_require__(54);
 
 	var _jubilationRect2 = _interopRequireDefault(_jubilationRect);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
@@ -9458,7 +9337,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = JubilationVerticalBarChart;
 
 /***/ },
-/* 60 */
+/* 58 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9468,11 +9347,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.YAxis = exports.XAxis = undefined;
 
-	var _xAxis = __webpack_require__(61);
+	var _xAxis = __webpack_require__(59);
 
 	var _xAxis2 = _interopRequireDefault(_xAxis);
 
-	var _yAxis = __webpack_require__(66);
+	var _yAxis = __webpack_require__(64);
 
 	var _yAxis2 = _interopRequireDefault(_yAxis);
 
@@ -9482,7 +9361,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.YAxis = _yAxis2.default;
 
 /***/ },
-/* 61 */
+/* 59 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9496,21 +9375,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _jubilationTick = __webpack_require__(62);
+	var _jubilationTick = __webpack_require__(60);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9623,7 +9502,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	XAxis.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 62 */
+/* 60 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9633,11 +9512,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.YTick = exports.XTick = undefined;
 
-	var _xTick = __webpack_require__(63);
+	var _xTick = __webpack_require__(61);
 
 	var _xTick2 = _interopRequireDefault(_xTick);
 
-	var _yTick = __webpack_require__(65);
+	var _yTick = __webpack_require__(63);
 
 	var _yTick2 = _interopRequireDefault(_yTick);
 
@@ -9647,7 +9526,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.YTick = _yTick2.default;
 
 /***/ },
-/* 63 */
+/* 61 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9664,7 +9543,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9702,7 +9581,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 64 */
+/* 62 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9719,7 +9598,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
@@ -9735,6 +9614,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * A line segment, defined by two endpoints. Returns an SVG line element.
 	 */
 	function JubilationLine(_ref, _ref2) {
+	  var JubilationContext = _ref2.JubilationContext;
+
 	  var _ref$x = _ref.x1,
 	      x1 = _ref$x === undefined ? 0 : _ref$x,
 	      _ref$y = _ref.y1,
@@ -9744,8 +9625,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	      _ref$y2 = _ref.y2,
 	      y2 = _ref$y2 === undefined ? 1 : _ref$y2,
 	      rest = _objectWithoutProperties(_ref, ['x1', 'y1', 'x2', 'y2']);
-
-	  var JubilationContext = _ref2.JubilationContext;
 
 	  var context = (0, _context2.default)(JubilationContext);
 	  var xScale = context.xScale,
@@ -9771,7 +9650,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	JubilationLine.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 65 */
+/* 63 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9788,7 +9667,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9826,7 +9705,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ },
-/* 66 */
+/* 64 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -9840,21 +9719,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _context = __webpack_require__(51);
+	var _context = __webpack_require__(49);
 
 	var _context2 = _interopRequireDefault(_context);
 
-	var _axis = __webpack_require__(57);
+	var _axis = __webpack_require__(55);
 
 	var _axis2 = _interopRequireDefault(_axis);
 
-	var _jubilationTick = __webpack_require__(62);
+	var _jubilationTick = __webpack_require__(60);
 
-	var _jubilationLabel = __webpack_require__(50);
+	var _jubilationLabel = __webpack_require__(48);
 
 	var _jubilationLabel2 = _interopRequireDefault(_jubilationLabel);
 
-	var _jubilationLine = __webpack_require__(64);
+	var _jubilationLine = __webpack_require__(62);
 
 	var _jubilationLine2 = _interopRequireDefault(_jubilationLine);
 
@@ -9970,15 +9849,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	YAxis.contextTypes = { JubilationContext: _react2.default.PropTypes.object };
 
 /***/ },
-/* 67 */
+/* 65 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	module.exports = __webpack_require__(68);
+	module.exports = __webpack_require__(66);
 
 /***/ },
-/* 68 */
+/* 66 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -9989,23 +9868,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOM
 	 */
 
 	/* globals __REACT_DEVTOOLS_GLOBAL_HOOK__*/
 
 	'use strict';
 
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactDefaultInjection = __webpack_require__(72);
-	var ReactMount = __webpack_require__(192);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactDefaultInjection = __webpack_require__(71);
+	var ReactMount = __webpack_require__(194);
 	var ReactReconciler = __webpack_require__(92);
 	var ReactUpdates = __webpack_require__(89);
-	var ReactVersion = __webpack_require__(29);
+	var ReactVersion = __webpack_require__(199);
 
-	var findDOMNode = __webpack_require__(197);
-	var getHostComponentFromComposite = __webpack_require__(198);
-	var renderSubtreeIntoContainer = __webpack_require__(199);
+	var findDOMNode = __webpack_require__(200);
+	var getHostComponentFromComposite = __webpack_require__(201);
+	var renderSubtreeIntoContainer = __webpack_require__(202);
 	var warning = __webpack_require__(11);
 
 	ReactDefaultInjection.inject();
@@ -10023,7 +9901,6 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	// Inject the runtime into a devtools global hook regardless of browser.
 	// Allows for debugging when the hook is injected on the page.
-	/* eslint-enable camelcase */
 	if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' && typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.inject === 'function') {
 	  __REACT_DEVTOOLS_GLOBAL_HOOK__.inject({
 	    ComponentTree: {
@@ -10070,7 +9947,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var expectedFeatures = [
 	    // shims
-	    Array.isArray, Array.prototype.every, Array.prototype.forEach, Array.prototype.indexOf, Array.prototype.map, Date.now, Function.prototype.bind, Object.keys, String.prototype.split, String.prototype.trim];
+	    Array.isArray, Array.prototype.every, Array.prototype.forEach, Array.prototype.indexOf, Array.prototype.map, Date.now, Function.prototype.bind, Object.keys, String.prototype.trim];
 
 	    for (var i = 0; i < expectedFeatures.length; i++) {
 	      if (!expectedFeatures[i]) {
@@ -10085,15 +9962,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var ReactInstrumentation = require('./ReactInstrumentation');
 	  var ReactDOMUnknownPropertyHook = require('./ReactDOMUnknownPropertyHook');
 	  var ReactDOMNullInputValuePropHook = require('./ReactDOMNullInputValuePropHook');
+	  var ReactDOMInvalidARIAHook = require('./ReactDOMInvalidARIAHook');
 
 	  ReactInstrumentation.debugTool.addHook(ReactDOMUnknownPropertyHook);
 	  ReactInstrumentation.debugTool.addHook(ReactDOMNullInputValuePropHook);
+	  ReactInstrumentation.debugTool.addHook(ReactDOMInvalidARIAHook);
 	}
 
 	module.exports = ReactDOM;
 
 /***/ },
-/* 69 */
+/* 67 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -10104,15 +9983,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMComponentTree
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var DOMProperty = __webpack_require__(70);
-	var ReactDOMComponentFlags = __webpack_require__(71);
+	var DOMProperty = __webpack_require__(69);
+	var ReactDOMComponentFlags = __webpack_require__(70);
 
 	var invariant = __webpack_require__(8);
 
@@ -10286,7 +10164,50 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMComponentTree;
 
 /***/ },
-/* 70 */
+/* 68 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright (c) 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+	'use strict';
+
+	/**
+	 * WARNING: DO NOT manually require this module.
+	 * This is a replacement for `invariant(...)` used by the error code system
+	 * and will _only_ be required by the corresponding babel pass.
+	 * It always throws.
+	 */
+
+	function reactProdInvariant(code) {
+	  var argCount = arguments.length - 1;
+
+	  var message = 'Minified React error #' + code + '; visit ' + 'http://facebook.github.io/react/docs/error-decoder.html?invariant=' + code;
+
+	  for (var argIdx = 0; argIdx < argCount; argIdx++) {
+	    message += '&args[]=' + encodeURIComponent(arguments[argIdx + 1]);
+	  }
+
+	  message += ' for the full message or use the non-minified dev environment' + ' for full errors and additional helpful warnings.';
+
+	  var error = new Error(message);
+	  error.name = 'Invariant Violation';
+	  error.framesToPop = 1; // we don't care about reactProdInvariant's own frame
+
+	  throw error;
+	}
+
+	module.exports = reactProdInvariant;
+
+/***/ },
+/* 69 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -10297,12 +10218,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DOMProperty
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
 
@@ -10468,9 +10388,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  /**
 	   * Mapping from lowercase property names to the properly cased version, used
 	   * to warn in the case of missing properties. Available only in __DEV__.
+	   *
+	   * autofocus is predefined, because adding it to the property whitelist
+	   * causes unintended side effects.
+	   *
 	   * @type {Object}
 	   */
-	  getPossibleStandardName:  false ? {} : null,
+	  getPossibleStandardName:  false ? { autofocus: 'autoFocus' } : null,
 
 	  /**
 	   * All of the isCustomAttribute() functions that have been injected.
@@ -10497,7 +10421,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = DOMProperty;
 
 /***/ },
-/* 71 */
+/* 70 */
 /***/ function(module, exports) {
 
 	/**
@@ -10508,7 +10432,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMComponentFlags
 	 */
 
 	'use strict';
@@ -10520,7 +10443,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMComponentFlags;
 
 /***/ },
-/* 72 */
+/* 71 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -10531,29 +10454,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDefaultInjection
 	 */
 
 	'use strict';
 
+	var ARIADOMPropertyConfig = __webpack_require__(72);
 	var BeforeInputEventPlugin = __webpack_require__(73);
 	var ChangeEventPlugin = __webpack_require__(88);
 	var DefaultEventPluginOrder = __webpack_require__(100);
 	var EnterLeaveEventPlugin = __webpack_require__(101);
 	var HTMLDOMPropertyConfig = __webpack_require__(106);
 	var ReactComponentBrowserEnvironment = __webpack_require__(107);
-	var ReactDOMComponent = __webpack_require__(121);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactDOMEmptyComponent = __webpack_require__(163);
-	var ReactDOMTreeTraversal = __webpack_require__(164);
-	var ReactDOMTextComponent = __webpack_require__(165);
-	var ReactDefaultBatchingStrategy = __webpack_require__(166);
-	var ReactEventListener = __webpack_require__(167);
-	var ReactInjection = __webpack_require__(170);
-	var ReactReconcileTransaction = __webpack_require__(171);
-	var SVGDOMPropertyConfig = __webpack_require__(179);
-	var SelectEventPlugin = __webpack_require__(180);
-	var SimpleEventPlugin = __webpack_require__(181);
+	var ReactDOMComponent = __webpack_require__(120);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactDOMEmptyComponent = __webpack_require__(165);
+	var ReactDOMTreeTraversal = __webpack_require__(166);
+	var ReactDOMTextComponent = __webpack_require__(167);
+	var ReactDefaultBatchingStrategy = __webpack_require__(168);
+	var ReactEventListener = __webpack_require__(169);
+	var ReactInjection = __webpack_require__(172);
+	var ReactReconcileTransaction = __webpack_require__(173);
+	var SVGDOMPropertyConfig = __webpack_require__(181);
+	var SelectEventPlugin = __webpack_require__(182);
+	var SimpleEventPlugin = __webpack_require__(183);
 
 	var alreadyInjected = false;
 
@@ -10591,6 +10514,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  ReactInjection.HostComponent.injectTextComponentClass(ReactDOMTextComponent);
 
+	  ReactInjection.DOMProperty.injectDOMPropertyConfig(ARIADOMPropertyConfig);
 	  ReactInjection.DOMProperty.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
 	  ReactInjection.DOMProperty.injectDOMPropertyConfig(SVGDOMPropertyConfig);
 
@@ -10609,6 +10533,84 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
+/* 72 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 */
+
+	'use strict';
+
+	var ARIADOMPropertyConfig = {
+	  Properties: {
+	    // Global States and Properties
+	    'aria-current': 0, // state
+	    'aria-details': 0,
+	    'aria-disabled': 0, // state
+	    'aria-hidden': 0, // state
+	    'aria-invalid': 0, // state
+	    'aria-keyshortcuts': 0,
+	    'aria-label': 0,
+	    'aria-roledescription': 0,
+	    // Widget Attributes
+	    'aria-autocomplete': 0,
+	    'aria-checked': 0,
+	    'aria-expanded': 0,
+	    'aria-haspopup': 0,
+	    'aria-level': 0,
+	    'aria-modal': 0,
+	    'aria-multiline': 0,
+	    'aria-multiselectable': 0,
+	    'aria-orientation': 0,
+	    'aria-placeholder': 0,
+	    'aria-pressed': 0,
+	    'aria-readonly': 0,
+	    'aria-required': 0,
+	    'aria-selected': 0,
+	    'aria-sort': 0,
+	    'aria-valuemax': 0,
+	    'aria-valuemin': 0,
+	    'aria-valuenow': 0,
+	    'aria-valuetext': 0,
+	    // Live Region Attributes
+	    'aria-atomic': 0,
+	    'aria-busy': 0,
+	    'aria-live': 0,
+	    'aria-relevant': 0,
+	    // Drag-and-Drop Attributes
+	    'aria-dropeffect': 0,
+	    'aria-grabbed': 0,
+	    // Relationship Attributes
+	    'aria-activedescendant': 0,
+	    'aria-colcount': 0,
+	    'aria-colindex': 0,
+	    'aria-colspan': 0,
+	    'aria-controls': 0,
+	    'aria-describedby': 0,
+	    'aria-errormessage': 0,
+	    'aria-flowto': 0,
+	    'aria-labelledby': 0,
+	    'aria-owns': 0,
+	    'aria-posinset': 0,
+	    'aria-rowcount': 0,
+	    'aria-rowindex': 0,
+	    'aria-rowspan': 0,
+	    'aria-setsize': 0
+	  },
+	  DOMAttributeNames: {},
+	  DOMPropertyNames: {}
+	};
+
+	module.exports = ARIADOMPropertyConfig;
+
+/***/ },
 /* 73 */
 /***/ function(module, exports, __webpack_require__) {
 
@@ -10620,21 +10622,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule BeforeInputEventPlugin
 	 */
 
 	'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var EventConstants = __webpack_require__(74);
-	var EventPropagators = __webpack_require__(75);
-	var ExecutionEnvironment = __webpack_require__(82);
-	var FallbackCompositionState = __webpack_require__(83);
+	var EventPropagators = __webpack_require__(74);
+	var ExecutionEnvironment = __webpack_require__(81);
+	var FallbackCompositionState = __webpack_require__(82);
 	var SyntheticCompositionEvent = __webpack_require__(85);
 	var SyntheticInputEvent = __webpack_require__(87);
-
-	var keyOf = __webpack_require__(25);
 
 	var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
 	var START_KEYCODE = 229;
@@ -10668,37 +10666,35 @@ return /******/ (function(modules) { // webpackBootstrap
 	var SPACEBAR_CODE = 32;
 	var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
 
-	var topLevelTypes = EventConstants.topLevelTypes;
-
 	// Events and their corresponding property names.
 	var eventTypes = {
 	  beforeInput: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onBeforeInput: null }),
-	      captured: keyOf({ onBeforeInputCapture: null })
+	      bubbled: 'onBeforeInput',
+	      captured: 'onBeforeInputCapture'
 	    },
-	    dependencies: [topLevelTypes.topCompositionEnd, topLevelTypes.topKeyPress, topLevelTypes.topTextInput, topLevelTypes.topPaste]
+	    dependencies: ['topCompositionEnd', 'topKeyPress', 'topTextInput', 'topPaste']
 	  },
 	  compositionEnd: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCompositionEnd: null }),
-	      captured: keyOf({ onCompositionEndCapture: null })
+	      bubbled: 'onCompositionEnd',
+	      captured: 'onCompositionEndCapture'
 	    },
-	    dependencies: [topLevelTypes.topBlur, topLevelTypes.topCompositionEnd, topLevelTypes.topKeyDown, topLevelTypes.topKeyPress, topLevelTypes.topKeyUp, topLevelTypes.topMouseDown]
+	    dependencies: ['topBlur', 'topCompositionEnd', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
 	  },
 	  compositionStart: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCompositionStart: null }),
-	      captured: keyOf({ onCompositionStartCapture: null })
+	      bubbled: 'onCompositionStart',
+	      captured: 'onCompositionStartCapture'
 	    },
-	    dependencies: [topLevelTypes.topBlur, topLevelTypes.topCompositionStart, topLevelTypes.topKeyDown, topLevelTypes.topKeyPress, topLevelTypes.topKeyUp, topLevelTypes.topMouseDown]
+	    dependencies: ['topBlur', 'topCompositionStart', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
 	  },
 	  compositionUpdate: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCompositionUpdate: null }),
-	      captured: keyOf({ onCompositionUpdateCapture: null })
+	      bubbled: 'onCompositionUpdate',
+	      captured: 'onCompositionUpdateCapture'
 	    },
-	    dependencies: [topLevelTypes.topBlur, topLevelTypes.topCompositionUpdate, topLevelTypes.topKeyDown, topLevelTypes.topKeyPress, topLevelTypes.topKeyUp, topLevelTypes.topMouseDown]
+	    dependencies: ['topBlur', 'topCompositionUpdate', 'topKeyDown', 'topKeyPress', 'topKeyUp', 'topMouseDown']
 	  }
 	};
 
@@ -10724,11 +10720,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function getCompositionEventType(topLevelType) {
 	  switch (topLevelType) {
-	    case topLevelTypes.topCompositionStart:
+	    case 'topCompositionStart':
 	      return eventTypes.compositionStart;
-	    case topLevelTypes.topCompositionEnd:
+	    case 'topCompositionEnd':
 	      return eventTypes.compositionEnd;
-	    case topLevelTypes.topCompositionUpdate:
+	    case 'topCompositionUpdate':
 	      return eventTypes.compositionUpdate;
 	  }
 	}
@@ -10742,7 +10738,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @return {boolean}
 	 */
 	function isFallbackCompositionStart(topLevelType, nativeEvent) {
-	  return topLevelType === topLevelTypes.topKeyDown && nativeEvent.keyCode === START_KEYCODE;
+	  return topLevelType === 'topKeyDown' && nativeEvent.keyCode === START_KEYCODE;
 	}
 
 	/**
@@ -10754,16 +10750,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function isFallbackCompositionEnd(topLevelType, nativeEvent) {
 	  switch (topLevelType) {
-	    case topLevelTypes.topKeyUp:
+	    case 'topKeyUp':
 	      // Command keys insert or clear IME input.
 	      return END_KEYCODES.indexOf(nativeEvent.keyCode) !== -1;
-	    case topLevelTypes.topKeyDown:
+	    case 'topKeyDown':
 	      // Expect IME keyCode on each keydown. If we get any other
 	      // code we must have exited earlier.
 	      return nativeEvent.keyCode !== START_KEYCODE;
-	    case topLevelTypes.topKeyPress:
-	    case topLevelTypes.topMouseDown:
-	    case topLevelTypes.topBlur:
+	    case 'topKeyPress':
+	    case 'topMouseDown':
+	    case 'topBlur':
 	      // Events are not possible without cancelling IME.
 	      return true;
 	    default:
@@ -10848,9 +10844,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function getNativeBeforeInputChars(topLevelType, nativeEvent) {
 	  switch (topLevelType) {
-	    case topLevelTypes.topCompositionEnd:
+	    case 'topCompositionEnd':
 	      return getDataFromCustomEvent(nativeEvent);
-	    case topLevelTypes.topKeyPress:
+	    case 'topKeyPress':
 	      /**
 	       * If native `textInput` events are available, our goal is to make
 	       * use of them. However, there is a special case: the spacebar key.
@@ -10873,7 +10869,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      hasSpaceKeypress = true;
 	      return SPACEBAR_CHAR;
 
-	    case topLevelTypes.topTextInput:
+	    case 'topTextInput':
 	      // Record the characters to be added to the DOM.
 	      var chars = nativeEvent.data;
 
@@ -10906,7 +10902,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // If composition event is available, we extract a string only at
 	  // compositionevent, otherwise extract it at fallback events.
 	  if (currentComposition) {
-	    if (topLevelType === topLevelTypes.topCompositionEnd || !canUseCompositionEvent && isFallbackCompositionEnd(topLevelType, nativeEvent)) {
+	    if (topLevelType === 'topCompositionEnd' || !canUseCompositionEvent && isFallbackCompositionEnd(topLevelType, nativeEvent)) {
 	      var chars = currentComposition.getData();
 	      FallbackCompositionState.release(currentComposition);
 	      currentComposition = null;
@@ -10916,11 +10912,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  switch (topLevelType) {
-	    case topLevelTypes.topPaste:
+	    case 'topPaste':
 	      // If a paste event occurs after a keypress, throw out the input
 	      // chars. Paste events should not lead to BeforeInput events.
 	      return null;
-	    case topLevelTypes.topKeyPress:
+	    case 'topKeyPress':
 	      /**
 	       * As of v27, Firefox may fire keypress events even when no character
 	       * will be inserted. A few possibilities:
@@ -10941,7 +10937,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return String.fromCharCode(nativeEvent.which);
 	      }
 	      return null;
-	    case topLevelTypes.topCompositionEnd:
+	    case 'topCompositionEnd':
 	      return useFallbackCompositionData ? null : nativeEvent.data;
 	    default:
 	      return null;
@@ -11017,122 +11013,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule EventConstants
 	 */
 
 	'use strict';
 
-	var keyMirror = __webpack_require__(23);
+	var EventPluginHub = __webpack_require__(75);
+	var EventPluginUtils = __webpack_require__(77);
 
-	var PropagationPhases = keyMirror({ bubbled: null, captured: null });
-
-	/**
-	 * Types of raw signals from the browser caught at the top level.
-	 */
-	var topLevelTypes = keyMirror({
-	  topAbort: null,
-	  topAnimationEnd: null,
-	  topAnimationIteration: null,
-	  topAnimationStart: null,
-	  topBlur: null,
-	  topCanPlay: null,
-	  topCanPlayThrough: null,
-	  topChange: null,
-	  topClick: null,
-	  topCompositionEnd: null,
-	  topCompositionStart: null,
-	  topCompositionUpdate: null,
-	  topContextMenu: null,
-	  topCopy: null,
-	  topCut: null,
-	  topDoubleClick: null,
-	  topDrag: null,
-	  topDragEnd: null,
-	  topDragEnter: null,
-	  topDragExit: null,
-	  topDragLeave: null,
-	  topDragOver: null,
-	  topDragStart: null,
-	  topDrop: null,
-	  topDurationChange: null,
-	  topEmptied: null,
-	  topEncrypted: null,
-	  topEnded: null,
-	  topError: null,
-	  topFocus: null,
-	  topInput: null,
-	  topInvalid: null,
-	  topKeyDown: null,
-	  topKeyPress: null,
-	  topKeyUp: null,
-	  topLoad: null,
-	  topLoadedData: null,
-	  topLoadedMetadata: null,
-	  topLoadStart: null,
-	  topMouseDown: null,
-	  topMouseMove: null,
-	  topMouseOut: null,
-	  topMouseOver: null,
-	  topMouseUp: null,
-	  topPaste: null,
-	  topPause: null,
-	  topPlay: null,
-	  topPlaying: null,
-	  topProgress: null,
-	  topRateChange: null,
-	  topReset: null,
-	  topScroll: null,
-	  topSeeked: null,
-	  topSeeking: null,
-	  topSelectionChange: null,
-	  topStalled: null,
-	  topSubmit: null,
-	  topSuspend: null,
-	  topTextInput: null,
-	  topTimeUpdate: null,
-	  topTouchCancel: null,
-	  topTouchEnd: null,
-	  topTouchMove: null,
-	  topTouchStart: null,
-	  topTransitionEnd: null,
-	  topVolumeChange: null,
-	  topWaiting: null,
-	  topWheel: null
-	});
-
-	var EventConstants = {
-	  topLevelTypes: topLevelTypes,
-	  PropagationPhases: PropagationPhases
-	};
-
-	module.exports = EventConstants;
-
-/***/ },
-/* 75 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule EventPropagators
-	 */
-
-	'use strict';
-
-	var EventConstants = __webpack_require__(74);
-	var EventPluginHub = __webpack_require__(76);
-	var EventPluginUtils = __webpack_require__(78);
-
-	var accumulateInto = __webpack_require__(80);
-	var forEachAccumulated = __webpack_require__(81);
+	var accumulateInto = __webpack_require__(79);
+	var forEachAccumulated = __webpack_require__(80);
 	var warning = __webpack_require__(11);
 
-	var PropagationPhases = EventConstants.PropagationPhases;
 	var getListener = EventPluginHub.getListener;
 
 	/**
@@ -11150,11 +11041,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * Mutating the event's members allows us to not have to create a wrapping
 	 * "dispatch" object that pairs the event with the listener.
 	 */
-	function accumulateDirectionalDispatches(inst, upwards, event) {
+	function accumulateDirectionalDispatches(inst, phase, event) {
 	  if (false) {
 	    process.env.NODE_ENV !== 'production' ? warning(inst, 'Dispatching inst must not be null') : void 0;
 	  }
-	  var phase = upwards ? PropagationPhases.bubbled : PropagationPhases.captured;
 	  var listener = listenerAtPhase(inst, event, phase);
 	  if (listener) {
 	    event._dispatchListeners = accumulateInto(event._dispatchListeners, listener);
@@ -11250,7 +11140,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = EventPropagators;
 
 /***/ },
-/* 76 */
+/* 75 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -11261,21 +11151,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule EventPluginHub
 	 */
 
 	'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var EventPluginRegistry = __webpack_require__(77);
-	var EventPluginUtils = __webpack_require__(78);
-	var ReactErrorUtils = __webpack_require__(79);
+	var EventPluginRegistry = __webpack_require__(76);
+	var EventPluginUtils = __webpack_require__(77);
+	var ReactErrorUtils = __webpack_require__(78);
 
-	var accumulateInto = __webpack_require__(80);
-	var forEachAccumulated = __webpack_require__(81);
+	var accumulateInto = __webpack_require__(79);
+	var forEachAccumulated = __webpack_require__(80);
 	var invariant = __webpack_require__(8);
 
 	/**
@@ -11317,6 +11206,28 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // https://github.com/facebook/react/pull/7232
 	  return '.' + inst._rootNodeID;
 	};
+
+	function isInteractive(tag) {
+	  return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+	}
+
+	function shouldPreventMouseEvent(name, type, props) {
+	  switch (name) {
+	    case 'onClick':
+	    case 'onClickCapture':
+	    case 'onDoubleClick':
+	    case 'onDoubleClickCapture':
+	    case 'onMouseDown':
+	    case 'onMouseDownCapture':
+	    case 'onMouseMove':
+	    case 'onMouseMoveCapture':
+	    case 'onMouseUp':
+	    case 'onMouseUpCapture':
+	      return !!(props.disabled && isInteractive(type));
+	    default:
+	      return false;
+	  }
+	}
 
 	/**
 	 * This is a unified interface for event plugins to be installed and configured.
@@ -11386,7 +11297,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @return {?function} The stored callback.
 	   */
 	  getListener: function getListener(inst, registrationName) {
+	    // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
+	    // live here; needs to be moved to a better place soon
 	    var bankForRegistrationName = listenerBank[registrationName];
+	    if (shouldPreventMouseEvent(registrationName, inst._currentElement.type, inst._currentElement.props)) {
+	      return null;
+	    }
 	    var key = getDictionaryKey(inst);
 	    return bankForRegistrationName && bankForRegistrationName[key];
 	  },
@@ -11508,7 +11424,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = EventPluginHub;
 
 /***/ },
-/* 77 */
+/* 76 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -11519,19 +11435,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule EventPluginRegistry
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
 
 	/**
 	 * Injectable ordering of event plugins.
 	 */
-	var EventPluginOrder = null;
+	var eventPluginOrder = null;
 
 	/**
 	 * Injectable mapping from names to event plugin modules.
@@ -11544,22 +11460,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @private
 	 */
 	function recomputePluginOrdering() {
-	  if (!EventPluginOrder) {
-	    // Wait until an `EventPluginOrder` is injected.
+	  if (!eventPluginOrder) {
+	    // Wait until an `eventPluginOrder` is injected.
 	    return;
 	  }
 	  for (var pluginName in namesToPlugins) {
-	    var PluginModule = namesToPlugins[pluginName];
-	    var pluginIndex = EventPluginOrder.indexOf(pluginName);
+	    var pluginModule = namesToPlugins[pluginName];
+	    var pluginIndex = eventPluginOrder.indexOf(pluginName);
 	    !(pluginIndex > -1) ?  false ? invariant(false, 'EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, `%s`.', pluginName) : _prodInvariant('96', pluginName) : void 0;
 	    if (EventPluginRegistry.plugins[pluginIndex]) {
 	      continue;
 	    }
-	    !PluginModule.extractEvents ?  false ? invariant(false, 'EventPluginRegistry: Event plugins must implement an `extractEvents` method, but `%s` does not.', pluginName) : _prodInvariant('97', pluginName) : void 0;
-	    EventPluginRegistry.plugins[pluginIndex] = PluginModule;
-	    var publishedEvents = PluginModule.eventTypes;
+	    !pluginModule.extractEvents ?  false ? invariant(false, 'EventPluginRegistry: Event plugins must implement an `extractEvents` method, but `%s` does not.', pluginName) : _prodInvariant('97', pluginName) : void 0;
+	    EventPluginRegistry.plugins[pluginIndex] = pluginModule;
+	    var publishedEvents = pluginModule.eventTypes;
 	    for (var eventName in publishedEvents) {
-	      !publishEventForPlugin(publishedEvents[eventName], PluginModule, eventName) ?  false ? invariant(false, 'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.', eventName, pluginName) : _prodInvariant('98', eventName, pluginName) : void 0;
+	      !publishEventForPlugin(publishedEvents[eventName], pluginModule, eventName) ?  false ? invariant(false, 'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.', eventName, pluginName) : _prodInvariant('98', eventName, pluginName) : void 0;
 	    }
 	  }
 	}
@@ -11572,7 +11488,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @return {boolean} True if the event was successfully published.
 	 * @private
 	 */
-	function publishEventForPlugin(dispatchConfig, PluginModule, eventName) {
+	function publishEventForPlugin(dispatchConfig, pluginModule, eventName) {
 	  !!EventPluginRegistry.eventNameDispatchConfigs.hasOwnProperty(eventName) ?  false ? invariant(false, 'EventPluginHub: More than one plugin attempted to publish the same event name, `%s`.', eventName) : _prodInvariant('99', eventName) : void 0;
 	  EventPluginRegistry.eventNameDispatchConfigs[eventName] = dispatchConfig;
 
@@ -11581,12 +11497,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	    for (var phaseName in phasedRegistrationNames) {
 	      if (phasedRegistrationNames.hasOwnProperty(phaseName)) {
 	        var phasedRegistrationName = phasedRegistrationNames[phaseName];
-	        publishRegistrationName(phasedRegistrationName, PluginModule, eventName);
+	        publishRegistrationName(phasedRegistrationName, pluginModule, eventName);
 	      }
 	    }
 	    return true;
 	  } else if (dispatchConfig.registrationName) {
-	    publishRegistrationName(dispatchConfig.registrationName, PluginModule, eventName);
+	    publishRegistrationName(dispatchConfig.registrationName, pluginModule, eventName);
 	    return true;
 	  }
 	  return false;
@@ -11600,10 +11516,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param {object} PluginModule Plugin publishing the event.
 	 * @private
 	 */
-	function publishRegistrationName(registrationName, PluginModule, eventName) {
+	function publishRegistrationName(registrationName, pluginModule, eventName) {
 	  !!EventPluginRegistry.registrationNameModules[registrationName] ?  false ? invariant(false, 'EventPluginHub: More than one plugin attempted to publish the same registration name, `%s`.', registrationName) : _prodInvariant('100', registrationName) : void 0;
-	  EventPluginRegistry.registrationNameModules[registrationName] = PluginModule;
-	  EventPluginRegistry.registrationNameDependencies[registrationName] = PluginModule.eventTypes[eventName].dependencies;
+	  EventPluginRegistry.registrationNameModules[registrationName] = pluginModule;
+	  EventPluginRegistry.registrationNameDependencies[registrationName] = pluginModule.eventTypes[eventName].dependencies;
 
 	  if (false) {
 	    var lowerCasedName = registrationName.toLowerCase();
@@ -11649,6 +11565,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @type {Object}
 	   */
 	  possibleRegistrationNames:  false ? {} : null,
+	  // Trust the developer to only use possibleRegistrationNames in __DEV__
 
 	  /**
 	   * Injects an ordering of plugins (by plugin name). This allows the ordering
@@ -11659,10 +11576,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @internal
 	   * @see {EventPluginHub.injection.injectEventPluginOrder}
 	   */
-	  injectEventPluginOrder: function injectEventPluginOrder(InjectedEventPluginOrder) {
-	    !!EventPluginOrder ?  false ? invariant(false, 'EventPluginRegistry: Cannot inject event plugin ordering more than once. You are likely trying to load more than one copy of React.') : _prodInvariant('101') : void 0;
+	  injectEventPluginOrder: function injectEventPluginOrder(injectedEventPluginOrder) {
+	    !!eventPluginOrder ?  false ? invariant(false, 'EventPluginRegistry: Cannot inject event plugin ordering more than once. You are likely trying to load more than one copy of React.') : _prodInvariant('101') : void 0;
 	    // Clone the ordering so it cannot be dynamically mutated.
-	    EventPluginOrder = Array.prototype.slice.call(InjectedEventPluginOrder);
+	    eventPluginOrder = Array.prototype.slice.call(injectedEventPluginOrder);
 	    recomputePluginOrdering();
 	  },
 
@@ -11682,10 +11599,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (!injectedNamesToPlugins.hasOwnProperty(pluginName)) {
 	        continue;
 	      }
-	      var PluginModule = injectedNamesToPlugins[pluginName];
-	      if (!namesToPlugins.hasOwnProperty(pluginName) || namesToPlugins[pluginName] !== PluginModule) {
+	      var pluginModule = injectedNamesToPlugins[pluginName];
+	      if (!namesToPlugins.hasOwnProperty(pluginName) || namesToPlugins[pluginName] !== pluginModule) {
 	        !!namesToPlugins[pluginName] ?  false ? invariant(false, 'EventPluginRegistry: Cannot inject two different event plugins using the same name, `%s`.', pluginName) : _prodInvariant('102', pluginName) : void 0;
-	        namesToPlugins[pluginName] = PluginModule;
+	        namesToPlugins[pluginName] = pluginModule;
 	        isOrderingDirty = true;
 	      }
 	    }
@@ -11706,13 +11623,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (dispatchConfig.registrationName) {
 	      return EventPluginRegistry.registrationNameModules[dispatchConfig.registrationName] || null;
 	    }
-	    for (var phase in dispatchConfig.phasedRegistrationNames) {
-	      if (!dispatchConfig.phasedRegistrationNames.hasOwnProperty(phase)) {
-	        continue;
-	      }
-	      var PluginModule = EventPluginRegistry.registrationNameModules[dispatchConfig.phasedRegistrationNames[phase]];
-	      if (PluginModule) {
-	        return PluginModule;
+	    if (dispatchConfig.phasedRegistrationNames !== undefined) {
+	      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
+	      // that it is not undefined.
+	      var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
+
+	      for (var phase in phasedRegistrationNames) {
+	        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
+	          continue;
+	        }
+	        var pluginModule = EventPluginRegistry.registrationNameModules[phasedRegistrationNames[phase]];
+	        if (pluginModule) {
+	          return pluginModule;
+	        }
 	      }
 	    }
 	    return null;
@@ -11723,7 +11646,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @private
 	   */
 	  _resetEventPlugins: function _resetEventPlugins() {
-	    EventPluginOrder = null;
+	    eventPluginOrder = null;
 	    for (var pluginName in namesToPlugins) {
 	      if (namesToPlugins.hasOwnProperty(pluginName)) {
 	        delete namesToPlugins[pluginName];
@@ -11760,7 +11683,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = EventPluginRegistry;
 
 /***/ },
-/* 78 */
+/* 77 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -11771,15 +11694,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule EventPluginUtils
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var EventConstants = __webpack_require__(74);
-	var ReactErrorUtils = __webpack_require__(79);
+	var ReactErrorUtils = __webpack_require__(78);
 
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
@@ -11809,17 +11730,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	var topLevelTypes = EventConstants.topLevelTypes;
-
 	function isEndish(topLevelType) {
-	  return topLevelType === topLevelTypes.topMouseUp || topLevelType === topLevelTypes.topTouchEnd || topLevelType === topLevelTypes.topTouchCancel;
+	  return topLevelType === 'topMouseUp' || topLevelType === 'topTouchEnd' || topLevelType === 'topTouchCancel';
 	}
 
 	function isMoveish(topLevelType) {
-	  return topLevelType === topLevelTypes.topMouseMove || topLevelType === topLevelTypes.topTouchMove;
+	  return topLevelType === 'topMouseMove' || topLevelType === 'topTouchMove';
 	}
 	function isStartish(topLevelType) {
-	  return topLevelType === topLevelTypes.topMouseDown || topLevelType === topLevelTypes.topTouchStart;
+	  return topLevelType === 'topMouseDown' || topLevelType === 'topTouchStart';
 	}
 
 	var validateEventDispatches;
@@ -11994,7 +11913,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = EventPluginUtils;
 
 /***/ },
-/* 79 */
+/* 78 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -12005,7 +11924,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactErrorUtils
+	 * 
 	 */
 
 	'use strict';
@@ -12015,19 +11934,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	/**
 	 * Call a function while guarding against errors that happens within it.
 	 *
-	 * @param {?String} name of the guard to use for logging or debugging
+	 * @param {String} name of the guard to use for logging or debugging
 	 * @param {Function} func The function to invoke
 	 * @param {*} a First argument
 	 * @param {*} b Second argument
 	 */
-	function invokeGuardedCallback(name, func, a, b) {
+	function invokeGuardedCallback(name, func, a) {
 	  try {
-	    return func(a, b);
+	    func(a);
 	  } catch (x) {
 	    if (caughtError === null) {
 	      caughtError = x;
 	    }
-	    return undefined;
 	  }
 	}
 
@@ -12060,11 +11978,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	   */
 	  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function' && typeof document !== 'undefined' && typeof document.createEvent === 'function') {
 	    var fakeNode = document.createElement('react');
-	    ReactErrorUtils.invokeGuardedCallback = function (name, func, a, b) {
-	      var boundFunc = func.bind(null, a, b);
+	    ReactErrorUtils.invokeGuardedCallback = function (name, func, a) {
+	      var boundFunc = func.bind(null, a);
 	      var evtType = 'react-' + name;
 	      fakeNode.addEventListener(evtType, boundFunc, false);
 	      var evt = document.createEvent('Event');
+	      // $FlowFixMe https://github.com/facebook/flow/issues/2336
 	      evt.initEvent(evtType, false, false);
 	      fakeNode.dispatchEvent(evt);
 	      fakeNode.removeEventListener(evtType, boundFunc, false);
@@ -12075,7 +11994,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactErrorUtils;
 
 /***/ },
-/* 80 */
+/* 79 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -12086,13 +12005,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule accumulateInto
 	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
 
@@ -12138,7 +12056,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = accumulateInto;
 
 /***/ },
-/* 81 */
+/* 80 */
 /***/ function(module, exports) {
 
 	/**
@@ -12149,7 +12067,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule forEachAccumulated
 	 * 
 	 */
 
@@ -12174,7 +12091,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = forEachAccumulated;
 
 /***/ },
-/* 82 */
+/* 81 */
 /***/ function(module, exports) {
 
 	/**
@@ -12214,7 +12131,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ExecutionEnvironment;
 
 /***/ },
-/* 83 */
+/* 82 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -12225,14 +12142,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule FallbackCompositionState
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var PooledClass = __webpack_require__(6);
+	var PooledClass = __webpack_require__(83);
 
 	var getTextContentAccessor = __webpack_require__(84);
 
@@ -12314,6 +12230,134 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = FallbackCompositionState;
 
 /***/ },
+/* 83 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	var _prodInvariant = __webpack_require__(68);
+
+	var invariant = __webpack_require__(8);
+
+	/**
+	 * Static poolers. Several custom versions for each potential number of
+	 * arguments. A completely generic pooler is easy to implement, but would
+	 * require accessing the `arguments` object. In each of these, `this` refers to
+	 * the Class itself, not an instance. If any others are needed, simply add them
+	 * here, or in their own files.
+	 */
+	var oneArgumentPooler = function oneArgumentPooler(copyFieldsFrom) {
+	  var Klass = this;
+	  if (Klass.instancePool.length) {
+	    var instance = Klass.instancePool.pop();
+	    Klass.call(instance, copyFieldsFrom);
+	    return instance;
+	  } else {
+	    return new Klass(copyFieldsFrom);
+	  }
+	};
+
+	var twoArgumentPooler = function twoArgumentPooler(a1, a2) {
+	  var Klass = this;
+	  if (Klass.instancePool.length) {
+	    var instance = Klass.instancePool.pop();
+	    Klass.call(instance, a1, a2);
+	    return instance;
+	  } else {
+	    return new Klass(a1, a2);
+	  }
+	};
+
+	var threeArgumentPooler = function threeArgumentPooler(a1, a2, a3) {
+	  var Klass = this;
+	  if (Klass.instancePool.length) {
+	    var instance = Klass.instancePool.pop();
+	    Klass.call(instance, a1, a2, a3);
+	    return instance;
+	  } else {
+	    return new Klass(a1, a2, a3);
+	  }
+	};
+
+	var fourArgumentPooler = function fourArgumentPooler(a1, a2, a3, a4) {
+	  var Klass = this;
+	  if (Klass.instancePool.length) {
+	    var instance = Klass.instancePool.pop();
+	    Klass.call(instance, a1, a2, a3, a4);
+	    return instance;
+	  } else {
+	    return new Klass(a1, a2, a3, a4);
+	  }
+	};
+
+	var fiveArgumentPooler = function fiveArgumentPooler(a1, a2, a3, a4, a5) {
+	  var Klass = this;
+	  if (Klass.instancePool.length) {
+	    var instance = Klass.instancePool.pop();
+	    Klass.call(instance, a1, a2, a3, a4, a5);
+	    return instance;
+	  } else {
+	    return new Klass(a1, a2, a3, a4, a5);
+	  }
+	};
+
+	var standardReleaser = function standardReleaser(instance) {
+	  var Klass = this;
+	  !(instance instanceof Klass) ?  false ? invariant(false, 'Trying to release an instance into a pool of a different type.') : _prodInvariant('25') : void 0;
+	  instance.destructor();
+	  if (Klass.instancePool.length < Klass.poolSize) {
+	    Klass.instancePool.push(instance);
+	  }
+	};
+
+	var DEFAULT_POOL_SIZE = 10;
+	var DEFAULT_POOLER = oneArgumentPooler;
+
+	/**
+	 * Augments `CopyConstructor` to be a poolable class, augmenting only the class
+	 * itself (statically) not adding any prototypical fields. Any CopyConstructor
+	 * you give this may have a `poolSize` property, and will look for a
+	 * prototypical `destructor` on instances.
+	 *
+	 * @param {Function} CopyConstructor Constructor that can be used to reset.
+	 * @param {Function} pooler Customizable pooler.
+	 */
+	var addPoolingTo = function addPoolingTo(CopyConstructor, pooler) {
+	  // Casting as any so that flow ignores the actual implementation and trusts
+	  // it to match the type we declared
+	  var NewKlass = CopyConstructor;
+	  NewKlass.instancePool = [];
+	  NewKlass.getPooled = pooler || DEFAULT_POOLER;
+	  if (!NewKlass.poolSize) {
+	    NewKlass.poolSize = DEFAULT_POOL_SIZE;
+	  }
+	  NewKlass.release = standardReleaser;
+	  return NewKlass;
+	};
+
+	var PooledClass = {
+	  addPoolingTo: addPoolingTo,
+	  oneArgumentPooler: oneArgumentPooler,
+	  twoArgumentPooler: twoArgumentPooler,
+	  threeArgumentPooler: threeArgumentPooler,
+	  fourArgumentPooler: fourArgumentPooler,
+	  fiveArgumentPooler: fiveArgumentPooler
+	};
+
+	module.exports = PooledClass;
+
+/***/ },
 /* 84 */
 /***/ function(module, exports, __webpack_require__) {
 
@@ -12325,12 +12369,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getTextContentAccessor
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	var contentKey = null;
 
@@ -12363,7 +12406,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticCompositionEvent
 	 */
 
 	'use strict';
@@ -12404,14 +12446,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticEvent
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var PooledClass = __webpack_require__(6);
+	var PooledClass = __webpack_require__(83);
 
 	var emptyFunction = __webpack_require__(12);
 	var warning = __webpack_require__(11);
@@ -12677,7 +12718,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticInputEvent
 	 */
 
 	'use strict';
@@ -12719,33 +12759,28 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ChangeEventPlugin
 	 */
 
 	'use strict';
 
-	var EventConstants = __webpack_require__(74);
-	var EventPluginHub = __webpack_require__(76);
-	var EventPropagators = __webpack_require__(75);
-	var ExecutionEnvironment = __webpack_require__(82);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var EventPluginHub = __webpack_require__(75);
+	var EventPropagators = __webpack_require__(74);
+	var ExecutionEnvironment = __webpack_require__(81);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactUpdates = __webpack_require__(89);
 	var SyntheticEvent = __webpack_require__(86);
 
 	var getEventTarget = __webpack_require__(97);
 	var isEventSupported = __webpack_require__(98);
 	var isTextInputElement = __webpack_require__(99);
-	var keyOf = __webpack_require__(25);
-
-	var topLevelTypes = EventConstants.topLevelTypes;
 
 	var eventTypes = {
 	  change: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onChange: null }),
-	      captured: keyOf({ onChangeCapture: null })
+	      bubbled: 'onChange',
+	      captured: 'onChangeCapture'
 	    },
-	    dependencies: [topLevelTypes.topBlur, topLevelTypes.topChange, topLevelTypes.topClick, topLevelTypes.topFocus, topLevelTypes.topInput, topLevelTypes.topKeyDown, topLevelTypes.topKeyUp, topLevelTypes.topSelectionChange]
+	    dependencies: ['topBlur', 'topChange', 'topClick', 'topFocus', 'topInput', 'topKeyDown', 'topKeyUp', 'topSelectionChange']
 	  }
 	};
 
@@ -12810,17 +12845,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	function getTargetInstForChangeEvent(topLevelType, targetInst) {
-	  if (topLevelType === topLevelTypes.topChange) {
+	  if (topLevelType === 'topChange') {
 	    return targetInst;
 	  }
 	}
 	function handleEventsForChangeEventIE8(topLevelType, target, targetInst) {
-	  if (topLevelType === topLevelTypes.topFocus) {
+	  if (topLevelType === 'topFocus') {
 	    // stopWatching() should be a noop here but we call it just in case we
 	    // missed a blur event somehow.
 	    stopWatchingForChangeEventIE8();
 	    startWatchingForChangeEventIE8(target, targetInst);
-	  } else if (topLevelType === topLevelTypes.topBlur) {
+	  } else if (topLevelType === 'topBlur') {
 	    stopWatchingForChangeEventIE8();
 	  }
 	}
@@ -12918,7 +12953,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * If a `change` event should be fired, returns the target's ID.
 	 */
 	function getTargetInstForInputEvent(topLevelType, targetInst) {
-	  if (topLevelType === topLevelTypes.topInput) {
+	  if (topLevelType === 'topInput') {
 	    // In modern browsers (i.e., not IE8 or IE9), the input event is exactly
 	    // what we want so fall through here and trigger an abstract event
 	    return targetInst;
@@ -12926,7 +12961,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	function handleEventsForInputEventIE(topLevelType, target, targetInst) {
-	  if (topLevelType === topLevelTypes.topFocus) {
+	  if (topLevelType === 'topFocus') {
 	    // In IE8, we can capture almost all .value changes by adding a
 	    // propertychange handler and looking for events with propertyName
 	    // equal to 'value'
@@ -12942,14 +12977,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // missed a blur event somehow.
 	    stopWatchingForValueChange();
 	    startWatchingForValueChange(target, targetInst);
-	  } else if (topLevelType === topLevelTypes.topBlur) {
+	  } else if (topLevelType === 'topBlur') {
 	    stopWatchingForValueChange();
 	  }
 	}
 
 	// For IE8 and IE9.
 	function getTargetInstForInputEventIE(topLevelType, targetInst) {
-	  if (topLevelType === topLevelTypes.topSelectionChange || topLevelType === topLevelTypes.topKeyUp || topLevelType === topLevelTypes.topKeyDown) {
+	  if (topLevelType === 'topSelectionChange' || topLevelType === 'topKeyUp' || topLevelType === 'topKeyDown') {
 	    // On the selectionchange event, the target is just document which isn't
 	    // helpful for us so just check activeElement instead.
 	    //
@@ -12978,7 +13013,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	function getTargetInstForClickEvent(topLevelType, targetInst) {
-	  if (topLevelType === topLevelTypes.topClick) {
+	  if (topLevelType === 'topClick') {
 	    return targetInst;
 	  }
 	}
@@ -13049,16 +13084,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactUpdates
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
 	var CallbackQueue = __webpack_require__(90);
-	var PooledClass = __webpack_require__(6);
+	var PooledClass = __webpack_require__(83);
 	var ReactFeatureFlags = __webpack_require__(91);
 	var ReactReconciler = __webpack_require__(92);
 	var Transaction = __webpack_require__(96);
@@ -13114,7 +13148,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  /* useCreateElement */true);
 	}
 
-	_assign(ReactUpdatesFlushTransaction.prototype, Transaction.Mixin, {
+	_assign(ReactUpdatesFlushTransaction.prototype, Transaction, {
 	  getTransactionWrappers: function getTransactionWrappers() {
 	    return TRANSACTION_WRAPPERS;
 	  },
@@ -13130,7 +13164,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  perform: function perform(method, scope, a) {
 	    // Essentially calls `this.reconcileTransaction.perform(method, scope, a)`
 	    // with this transaction's wrappers around it.
-	    return Transaction.Mixin.perform.call(this, this.reconcileTransaction.perform, this.reconcileTransaction, method, scope, a);
+	    return Transaction.perform.call(this, this.reconcileTransaction.perform, this.reconcileTransaction, method, scope, a);
 	  }
 	});
 
@@ -13138,7 +13172,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function batchedUpdates(callback, a, b, c, d, e) {
 	  ensureInjected();
-	  batchingStrategy.batchedUpdates(callback, a, b, c, d, e);
+	  return batchingStrategy.batchedUpdates(callback, a, b, c, d, e);
 	}
 
 	/**
@@ -13184,7 +13218,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (ReactFeatureFlags.logTopLevelRenders) {
 	      var namedComponent = component;
 	      // Duck type TopLevelWrapper. This is probably always true.
-	      if (component._currentElement.props === component._renderedComponent._currentElement) {
+	      if (component._currentElement.type.isReactTopLevelWrapper) {
 	        namedComponent = component._renderedComponent;
 	      }
 	      markerName = 'React update: ' + namedComponent.getName();
@@ -13305,15 +13339,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule CallbackQueue
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7),
-	    _assign = __webpack_require__(4);
+	var _prodInvariant = __webpack_require__(68);
 
-	var PooledClass = __webpack_require__(6);
+	function _classCallCheck(instance, Constructor) {
+	  if (!(instance instanceof Constructor)) {
+	    throw new TypeError("Cannot call a class as a function");
+	  }
+	}
+
+	var PooledClass = __webpack_require__(83);
 
 	var invariant = __webpack_require__(8);
 
@@ -13328,12 +13367,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @implements PooledClass
 	 * @internal
 	 */
-	function CallbackQueue() {
-	  this._callbacks = null;
-	  this._contexts = null;
-	}
 
-	_assign(CallbackQueue.prototype, {
+	var CallbackQueue = function () {
+	  function CallbackQueue(arg) {
+	    _classCallCheck(this, CallbackQueue);
+
+	    this._callbacks = null;
+	    this._contexts = null;
+	    this._arg = arg;
+	  }
 
 	  /**
 	   * Enqueues a callback to be invoked when `notifyAll` is invoked.
@@ -13342,12 +13384,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @param {?object} context Context to call `callback` with.
 	   * @internal
 	   */
-	  enqueue: function enqueue(callback, context) {
+
+	  CallbackQueue.prototype.enqueue = function enqueue(callback, context) {
 	    this._callbacks = this._callbacks || [];
-	    this._contexts = this._contexts || [];
 	    this._callbacks.push(callback);
+	    this._contexts = this._contexts || [];
 	    this._contexts.push(context);
-	  },
+	  };
 
 	  /**
 	   * Invokes all enqueued callbacks and clears the queue. This is invoked after
@@ -13355,54 +13398,57 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @internal
 	   */
-	  notifyAll: function notifyAll() {
+
+	  CallbackQueue.prototype.notifyAll = function notifyAll() {
 	    var callbacks = this._callbacks;
 	    var contexts = this._contexts;
-	    if (callbacks) {
+	    var arg = this._arg;
+	    if (callbacks && contexts) {
 	      !(callbacks.length === contexts.length) ?  false ? invariant(false, 'Mismatched list of contexts in callback queue') : _prodInvariant('24') : void 0;
 	      this._callbacks = null;
 	      this._contexts = null;
 	      for (var i = 0; i < callbacks.length; i++) {
-	        callbacks[i].call(contexts[i]);
+	        callbacks[i].call(contexts[i], arg);
 	      }
 	      callbacks.length = 0;
 	      contexts.length = 0;
 	    }
-	  },
+	  };
 
-	  checkpoint: function checkpoint() {
+	  CallbackQueue.prototype.checkpoint = function checkpoint() {
 	    return this._callbacks ? this._callbacks.length : 0;
-	  },
+	  };
 
-	  rollback: function rollback(len) {
-	    if (this._callbacks) {
+	  CallbackQueue.prototype.rollback = function rollback(len) {
+	    if (this._callbacks && this._contexts) {
 	      this._callbacks.length = len;
 	      this._contexts.length = len;
 	    }
-	  },
+	  };
 
 	  /**
 	   * Resets the internal queue.
 	   *
 	   * @internal
 	   */
-	  reset: function reset() {
+
+	  CallbackQueue.prototype.reset = function reset() {
 	    this._callbacks = null;
 	    this._contexts = null;
-	  },
+	  };
 
 	  /**
 	   * `PooledClass` looks for this.
 	   */
-	  destructor: function destructor() {
+
+	  CallbackQueue.prototype.destructor = function destructor() {
 	    this.reset();
-	  }
+	  };
 
-	});
+	  return CallbackQueue;
+	}();
 
-	PooledClass.addPoolingTo(CallbackQueue);
-
-	module.exports = CallbackQueue;
+	module.exports = PooledClass.addPoolingTo(CallbackQueue);
 
 /***/ },
 /* 91 */
@@ -13416,7 +13462,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactFeatureFlags
 	 * 
 	 */
 
@@ -13443,7 +13488,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactReconciler
 	 */
 
 	'use strict';
@@ -13616,10 +13660,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactRef
+	 * 
 	 */
 
 	'use strict';
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 	var ReactOwner = __webpack_require__(94);
 
@@ -13644,7 +13690,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	ReactRef.attachRefs = function (instance, element) {
-	  if (element === null || element === false) {
+	  if (element === null || (typeof element === 'undefined' ? 'undefined' : _typeof(element)) !== 'object') {
 	    return;
 	  }
 	  var ref = element.ref;
@@ -13666,19 +13712,27 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // is made. It probably belongs where the key checking and
 	  // instantiateReactComponent is done.
 
-	  var prevEmpty = prevElement === null || prevElement === false;
-	  var nextEmpty = nextElement === null || nextElement === false;
+	  var prevRef = null;
+	  var prevOwner = null;
+	  if (prevElement !== null && (typeof prevElement === 'undefined' ? 'undefined' : _typeof(prevElement)) === 'object') {
+	    prevRef = prevElement.ref;
+	    prevOwner = prevElement._owner;
+	  }
 
-	  return (
-	    // This has a few false positives w/r/t empty components.
-	    prevEmpty || nextEmpty || nextElement.ref !== prevElement.ref ||
-	    // If owner changes but we have an unchanged function ref, don't update refs
-	    typeof nextElement.ref === 'string' && nextElement._owner !== prevElement._owner
-	  );
+	  var nextRef = null;
+	  var nextOwner = null;
+	  if (nextElement !== null && (typeof nextElement === 'undefined' ? 'undefined' : _typeof(nextElement)) === 'object') {
+	    nextRef = nextElement.ref;
+	    nextOwner = nextElement._owner;
+	  }
+
+	  return prevRef !== nextRef ||
+	  // If owner changes but we have an unchanged function ref, don't update refs
+	  typeof nextRef === 'string' && nextOwner !== prevOwner;
 	};
 
 	ReactRef.detachRefs = function (instance, element) {
-	  if (element === null || element === false) {
+	  if (element === null || (typeof element === 'undefined' ? 'undefined' : _typeof(element)) !== 'object') {
 	    return;
 	  }
 	  var ref = element.ref;
@@ -13701,14 +13755,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactOwner
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
+
+	/**
+	 * @param {?object} object
+	 * @return {boolean} True if `object` is a valid owner.
+	 * @final
+	 */
+	function isValidOwner(object) {
+	  return !!(object && typeof object.attachRef === 'function' && typeof object.detachRef === 'function');
+	}
 
 	/**
 	 * ReactOwners are capable of storing references to owned components.
@@ -13741,16 +13804,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @class ReactOwner
 	 */
 	var ReactOwner = {
-
-	  /**
-	   * @param {?object} object
-	   * @return {boolean} True if `object` is a valid owner.
-	   * @final
-	   */
-	  isValidOwner: function isValidOwner(object) {
-	    return !!(object && typeof object.attachRef === 'function' && typeof object.detachRef === 'function');
-	  },
-
 	  /**
 	   * Adds a component by ref to an owner component.
 	   *
@@ -13761,7 +13814,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @internal
 	   */
 	  addComponentAsRefTo: function addComponentAsRefTo(component, ref, owner) {
-	    !ReactOwner.isValidOwner(owner) ?  false ? invariant(false, 'addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('119') : void 0;
+	    !isValidOwner(owner) ?  false ? invariant(false, 'addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('119') : void 0;
 	    owner.attachRef(ref, component);
 	  },
 
@@ -13775,7 +13828,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @internal
 	   */
 	  removeComponentAsRefFrom: function removeComponentAsRefFrom(component, ref, owner) {
-	    !ReactOwner.isValidOwner(owner) ?  false ? invariant(false, 'removeComponentAsRefFrom(...): Only a ReactOwner can have refs. You might be removing a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('120') : void 0;
+	    !isValidOwner(owner) ?  false ? invariant(false, 'removeComponentAsRefFrom(...): Only a ReactOwner can have refs. You might be removing a ref to a component that was not created inside a component\'s `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).') : _prodInvariant('120') : void 0;
 	    var ownerPublicInstance = owner.getPublicInstance();
 	    // Check that `component`'s owner is still alive and that `component` is still the current ref
 	    // because we do not want to detach the ref if another component stole it.
@@ -13800,10 +13853,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactInstrumentation
+	 * 
 	 */
 
 	'use strict';
+
+	// Trust the developer to only use ReactInstrumentation with a __DEV__ check
 
 	var debugTool = null;
 
@@ -13826,14 +13881,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule Transaction
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
+
+	var OBSERVED_ERROR = {};
 
 	/**
 	 * `Transaction` creates a black box that is able to wrap any method such that
@@ -13896,7 +13953,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 *
 	 * @class Transaction
 	 */
-	var Mixin = {
+	var TransactionImpl = {
 	  /**
 	   * Sets up this instance so that it is prepared for collecting metrics. Does
 	   * so such that this setup method may be used on an instance that is already
@@ -13986,10 +14043,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // OBSERVED_ERROR state before overwriting it with the real return value
 	        // of initialize -- if it's still set to OBSERVED_ERROR in the finally
 	        // block, it means wrapper.initialize threw.
-	        this.wrapperInitData[i] = Transaction.OBSERVED_ERROR;
+	        this.wrapperInitData[i] = OBSERVED_ERROR;
 	        this.wrapperInitData[i] = wrapper.initialize ? wrapper.initialize.call(this) : null;
 	      } finally {
-	        if (this.wrapperInitData[i] === Transaction.OBSERVED_ERROR) {
+	        if (this.wrapperInitData[i] === OBSERVED_ERROR) {
 	          // The initializer for wrapper i threw an error; initialize the
 	          // remaining wrappers but silence any exceptions from them to ensure
 	          // that the first error is the one to bubble up.
@@ -14020,7 +14077,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // close -- if it's still set to true in the finally block, it means
 	        // wrapper.close threw.
 	        errorThrown = true;
-	        if (initData !== Transaction.OBSERVED_ERROR && wrapper.close) {
+	        if (initData !== OBSERVED_ERROR && wrapper.close) {
 	          wrapper.close.call(this, initData);
 	        }
 	        errorThrown = false;
@@ -14039,18 +14096,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	var Transaction = {
-
-	  Mixin: Mixin,
-
-	  /**
-	   * Token to look for to determine if an error occurred.
-	   */
-	  OBSERVED_ERROR: {}
-
-	};
-
-	module.exports = Transaction;
+	module.exports = TransactionImpl;
 
 /***/ },
 /* 97 */
@@ -14064,7 +14110,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getEventTarget
 	 */
 
 	'use strict';
@@ -14104,12 +14149,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule isEventSupported
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	var useHasFeature;
 	if (ExecutionEnvironment.canUseDOM) {
@@ -14169,7 +14213,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule isTextInputElement
 	 * 
 	 */
 
@@ -14215,7 +14258,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ },
 /* 100 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	/**
 	 * Copyright 2013-present, Facebook, Inc.
@@ -14225,12 +14268,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DefaultEventPluginOrder
 	 */
 
 	'use strict';
-
-	var keyOf = __webpack_require__(25);
 
 	/**
 	 * Module that is injectable into `EventPluginHub`, that specifies a
@@ -14241,7 +14281,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
 	 * preventing default on events is convenient in `SimpleEventPlugin` handlers.
 	 */
-	var DefaultEventPluginOrder = [keyOf({ ResponderEventPlugin: null }), keyOf({ SimpleEventPlugin: null }), keyOf({ TapEventPlugin: null }), keyOf({ EnterLeaveEventPlugin: null }), keyOf({ ChangeEventPlugin: null }), keyOf({ SelectEventPlugin: null }), keyOf({ BeforeInputEventPlugin: null })];
+
+	var DefaultEventPluginOrder = ['ResponderEventPlugin', 'SimpleEventPlugin', 'TapEventPlugin', 'EnterLeaveEventPlugin', 'ChangeEventPlugin', 'SelectEventPlugin', 'BeforeInputEventPlugin'];
 
 	module.exports = DefaultEventPluginOrder;
 
@@ -14257,28 +14298,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule EnterLeaveEventPlugin
 	 */
 
 	'use strict';
 
-	var EventConstants = __webpack_require__(74);
-	var EventPropagators = __webpack_require__(75);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var EventPropagators = __webpack_require__(74);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var SyntheticMouseEvent = __webpack_require__(102);
-
-	var keyOf = __webpack_require__(25);
-
-	var topLevelTypes = EventConstants.topLevelTypes;
 
 	var eventTypes = {
 	  mouseEnter: {
-	    registrationName: keyOf({ onMouseEnter: null }),
-	    dependencies: [topLevelTypes.topMouseOut, topLevelTypes.topMouseOver]
+	    registrationName: 'onMouseEnter',
+	    dependencies: ['topMouseOut', 'topMouseOver']
 	  },
 	  mouseLeave: {
-	    registrationName: keyOf({ onMouseLeave: null }),
-	    dependencies: [topLevelTypes.topMouseOut, topLevelTypes.topMouseOver]
+	    registrationName: 'onMouseLeave',
+	    dependencies: ['topMouseOut', 'topMouseOver']
 	  }
 	};
 
@@ -14294,10 +14329,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * the `mouseover` top-level event.
 	   */
 	  extractEvents: function extractEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
-	    if (topLevelType === topLevelTypes.topMouseOver && (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
+	    if (topLevelType === 'topMouseOver' && (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
 	      return null;
 	    }
-	    if (topLevelType !== topLevelTypes.topMouseOut && topLevelType !== topLevelTypes.topMouseOver) {
+	    if (topLevelType !== 'topMouseOut' && topLevelType !== 'topMouseOver') {
 	      // Must not be a mouse in or mouse out - ignoring.
 	      return null;
 	    }
@@ -14318,7 +14353,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    var from;
 	    var to;
-	    if (topLevelType === topLevelTypes.topMouseOut) {
+	    if (topLevelType === 'topMouseOut') {
 	      from = targetInst;
 	      var related = nativeEvent.relatedTarget || nativeEvent.toElement;
 	      to = related ? ReactDOMComponentTree.getClosestInstanceFromNode(related) : null;
@@ -14367,7 +14402,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticMouseEvent
 	 */
 
 	'use strict';
@@ -14444,7 +14478,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticUIEvent
 	 */
 
 	'use strict';
@@ -14508,7 +14541,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ViewportMetrics
 	 */
 
 	'use strict';
@@ -14540,7 +14572,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getEventModifierState
 	 */
 
 	'use strict';
@@ -14588,12 +14619,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule HTMLDOMPropertyConfig
 	 */
 
 	'use strict';
 
-	var DOMProperty = __webpack_require__(70);
+	var DOMProperty = __webpack_require__(69);
 
 	var MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
 	var HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
@@ -14805,13 +14835,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactComponentBrowserEnvironment
 	 */
 
 	'use strict';
 
 	var DOMChildrenOperations = __webpack_require__(108);
-	var ReactDOMIDOperations = __webpack_require__(120);
+	var ReactDOMIDOperations = __webpack_require__(119);
 
 	/**
 	 * Abstracts away all functionality of the reconciler that requires knowledge of
@@ -14840,15 +14869,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DOMChildrenOperations
 	 */
 
 	'use strict';
 
 	var DOMLazyTree = __webpack_require__(109);
 	var Danger = __webpack_require__(115);
-	var ReactMultiChildUpdateTypes = __webpack_require__(119);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactInstrumentation = __webpack_require__(95);
 
 	var createMicrosoftUnsafeLocalFunction = __webpack_require__(112);
@@ -14946,7 +14973,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  if (false) {
-	    ReactInstrumentation.debugTool.onHostOperation(ReactDOMComponentTree.getInstanceFromNode(openingComment)._debugID, 'replace text', stringText);
+	    ReactInstrumentation.debugTool.onHostOperation({
+	      instanceID: ReactDOMComponentTree.getInstanceFromNode(openingComment)._debugID,
+	      type: 'replace text',
+	      payload: stringText
+	    });
 	  }
 	}
 
@@ -14955,11 +14986,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	  dangerouslyReplaceNodeWithMarkup = function dangerouslyReplaceNodeWithMarkup(oldChild, markup, prevInstance) {
 	    Danger.dangerouslyReplaceNodeWithMarkup(oldChild, markup);
 	    if (prevInstance._debugID !== 0) {
-	      ReactInstrumentation.debugTool.onHostOperation(prevInstance._debugID, 'replace with', markup.toString());
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: prevInstance._debugID,
+	        type: 'replace with',
+	        payload: markup.toString()
+	      });
 	    } else {
 	      var nextInstance = ReactDOMComponentTree.getInstanceFromNode(markup.node);
 	      if (nextInstance._debugID !== 0) {
-	        ReactInstrumentation.debugTool.onHostOperation(nextInstance._debugID, 'mount', markup.toString());
+	        ReactInstrumentation.debugTool.onHostOperation({
+	          instanceID: nextInstance._debugID,
+	          type: 'mount',
+	          payload: markup.toString()
+	        });
 	      }
 	    }
 	  };
@@ -14989,34 +15028,54 @@ return /******/ (function(modules) { // webpackBootstrap
 	    for (var k = 0; k < updates.length; k++) {
 	      var update = updates[k];
 	      switch (update.type) {
-	        case ReactMultiChildUpdateTypes.INSERT_MARKUP:
+	        case 'INSERT_MARKUP':
 	          insertLazyTreeChildAt(parentNode, update.content, getNodeAfter(parentNode, update.afterNode));
 	          if (false) {
-	            ReactInstrumentation.debugTool.onHostOperation(parentNodeDebugID, 'insert child', { toIndex: update.toIndex, content: update.content.toString() });
+	            ReactInstrumentation.debugTool.onHostOperation({
+	              instanceID: parentNodeDebugID,
+	              type: 'insert child',
+	              payload: { toIndex: update.toIndex, content: update.content.toString() }
+	            });
 	          }
 	          break;
-	        case ReactMultiChildUpdateTypes.MOVE_EXISTING:
+	        case 'MOVE_EXISTING':
 	          moveChild(parentNode, update.fromNode, getNodeAfter(parentNode, update.afterNode));
 	          if (false) {
-	            ReactInstrumentation.debugTool.onHostOperation(parentNodeDebugID, 'move child', { fromIndex: update.fromIndex, toIndex: update.toIndex });
+	            ReactInstrumentation.debugTool.onHostOperation({
+	              instanceID: parentNodeDebugID,
+	              type: 'move child',
+	              payload: { fromIndex: update.fromIndex, toIndex: update.toIndex }
+	            });
 	          }
 	          break;
-	        case ReactMultiChildUpdateTypes.SET_MARKUP:
+	        case 'SET_MARKUP':
 	          setInnerHTML(parentNode, update.content);
 	          if (false) {
-	            ReactInstrumentation.debugTool.onHostOperation(parentNodeDebugID, 'replace children', update.content.toString());
+	            ReactInstrumentation.debugTool.onHostOperation({
+	              instanceID: parentNodeDebugID,
+	              type: 'replace children',
+	              payload: update.content.toString()
+	            });
 	          }
 	          break;
-	        case ReactMultiChildUpdateTypes.TEXT_CONTENT:
+	        case 'TEXT_CONTENT':
 	          setTextContent(parentNode, update.content);
 	          if (false) {
-	            ReactInstrumentation.debugTool.onHostOperation(parentNodeDebugID, 'replace text', update.content.toString());
+	            ReactInstrumentation.debugTool.onHostOperation({
+	              instanceID: parentNodeDebugID,
+	              type: 'replace text',
+	              payload: update.content.toString()
+	            });
 	          }
 	          break;
-	        case ReactMultiChildUpdateTypes.REMOVE_NODE:
+	        case 'REMOVE_NODE':
 	          removeChild(parentNode, update.fromNode);
 	          if (false) {
-	            ReactInstrumentation.debugTool.onHostOperation(parentNodeDebugID, 'remove child', { fromIndex: update.fromIndex });
+	            ReactInstrumentation.debugTool.onHostOperation({
+	              instanceID: parentNodeDebugID,
+	              type: 'remove child',
+	              payload: { fromIndex: update.fromIndex }
+	            });
 	          }
 	          break;
 	      }
@@ -15039,7 +15098,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DOMLazyTree
 	 */
 
 	'use strict';
@@ -15162,7 +15220,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DOMNamespaces
 	 */
 
 	'use strict';
@@ -15187,12 +15244,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule setInnerHTML
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 	var DOMNamespaces = __webpack_require__(110);
 
 	var WHITESPACE_TEST = /^[ \r\n\t\f]/;
@@ -15290,7 +15346,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule createMicrosoftUnsafeLocalFunction
 	 */
 
 	/* globals MSApp */
@@ -15327,12 +15382,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule setTextContent
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 	var escapeTextContentForBrowser = __webpack_require__(114);
 	var setInnerHTML = __webpack_require__(111);
 
@@ -15361,6 +15415,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	if (ExecutionEnvironment.canUseDOM) {
 	  if (!('textContent' in document.documentElement)) {
 	    setTextContent = function setTextContent(node, text) {
+	      if (node.nodeType === 3) {
+	        node.nodeValue = text;
+	        return;
+	      }
 	      setInnerHTML(node, escapeTextContentForBrowser(text));
 	    };
 	  }
@@ -15405,7 +15463,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 	 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	 *
-	 * @providesModule escapeTextContentForBrowser
 	 */
 
 	'use strict';
@@ -15508,15 +15565,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule Danger
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var DOMLazyTree = __webpack_require__(109);
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	var createNodesFromMarkup = __webpack_require__(116);
 	var emptyFunction = __webpack_require__(12);
@@ -15568,7 +15624,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/*eslint-disable fb-www/unsafe-html*/
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	var createArrayFromMixed = __webpack_require__(117);
 	var getMarkupWrap = __webpack_require__(118);
@@ -15788,7 +15844,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/*eslint-disable fb-www/unsafe-html */
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	var invariant = __webpack_require__(8);
 
@@ -15881,50 +15937,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactMultiChildUpdateTypes
-	 */
-
-	'use strict';
-
-	var keyMirror = __webpack_require__(23);
-
-	/**
-	 * When a component's children are updated, a series of update configuration
-	 * objects are created in order to batch and serialize the required changes.
-	 *
-	 * Enumerates all the possible types of update configurations.
-	 *
-	 * @internal
-	 */
-	var ReactMultiChildUpdateTypes = keyMirror({
-	  INSERT_MARKUP: null,
-	  MOVE_EXISTING: null,
-	  REMOVE_NODE: null,
-	  SET_MARKUP: null,
-	  TEXT_CONTENT: null
-	});
-
-	module.exports = ReactMultiChildUpdateTypes;
-
-/***/ },
-/* 120 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule ReactDOMIDOperations
 	 */
 
 	'use strict';
 
 	var DOMChildrenOperations = __webpack_require__(108);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 
 	/**
 	 * Operations used to process updates to DOM nodes.
@@ -15946,7 +15964,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMIDOperations;
 
 /***/ },
-/* 121 */
+/* 120 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -15957,7 +15975,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMComponent
 	 */
 
 	/* global hasOwnProperty:true */
@@ -15966,37 +15983,34 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
-	var AutoFocusUtils = __webpack_require__(122);
-	var CSSPropertyOperations = __webpack_require__(124);
+	var AutoFocusUtils = __webpack_require__(121);
+	var CSSPropertyOperations = __webpack_require__(123);
 	var DOMLazyTree = __webpack_require__(109);
 	var DOMNamespaces = __webpack_require__(110);
-	var DOMProperty = __webpack_require__(70);
-	var DOMPropertyOperations = __webpack_require__(132);
-	var EventConstants = __webpack_require__(74);
-	var EventPluginHub = __webpack_require__(76);
-	var EventPluginRegistry = __webpack_require__(77);
-	var ReactBrowserEventEmitter = __webpack_require__(134);
-	var ReactDOMButton = __webpack_require__(137);
-	var ReactDOMComponentFlags = __webpack_require__(71);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactDOMInput = __webpack_require__(139);
-	var ReactDOMOption = __webpack_require__(141);
-	var ReactDOMSelect = __webpack_require__(142);
-	var ReactDOMTextarea = __webpack_require__(143);
+	var DOMProperty = __webpack_require__(69);
+	var DOMPropertyOperations = __webpack_require__(131);
+	var EventPluginHub = __webpack_require__(75);
+	var EventPluginRegistry = __webpack_require__(76);
+	var ReactBrowserEventEmitter = __webpack_require__(133);
+	var ReactDOMComponentFlags = __webpack_require__(70);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactDOMInput = __webpack_require__(136);
+	var ReactDOMOption = __webpack_require__(139);
+	var ReactDOMSelect = __webpack_require__(140);
+	var ReactDOMTextarea = __webpack_require__(141);
 	var ReactInstrumentation = __webpack_require__(95);
-	var ReactMultiChild = __webpack_require__(144);
-	var ReactServerRenderingTransaction = __webpack_require__(159);
+	var ReactMultiChild = __webpack_require__(142);
+	var ReactServerRenderingTransaction = __webpack_require__(161);
 
 	var emptyFunction = __webpack_require__(12);
 	var escapeTextContentForBrowser = __webpack_require__(114);
 	var invariant = __webpack_require__(8);
 	var isEventSupported = __webpack_require__(98);
-	var keyOf = __webpack_require__(25);
-	var shallowEqual = __webpack_require__(154);
-	var validateDOMNesting = __webpack_require__(162);
+	var shallowEqual = __webpack_require__(150);
+	var validateDOMNesting = __webpack_require__(164);
 	var warning = __webpack_require__(11);
 
 	var Flags = ReactDOMComponentFlags;
@@ -16008,8 +16022,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	// For quickly matching children type, to test if can be treated as content.
 	var CONTENT_TYPES = { 'string': true, 'number': true };
 
-	var STYLE = keyOf({ style: null });
-	var HTML = keyOf({ __html: null });
+	var STYLE = 'style';
+	var HTML = '__html';
 	var RESERVED_PROPS = {
 	  children: null,
 	  dangerouslySetInnerHTML: null,
@@ -16216,7 +16230,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  switch (inst._tag) {
 	    case 'iframe':
 	    case 'object':
-	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topLoad, 'load', node)];
+	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node)];
 	      break;
 	    case 'video':
 	    case 'audio':
@@ -16225,23 +16239,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // Create listener for each media event
 	      for (var event in mediaEvents) {
 	        if (mediaEvents.hasOwnProperty(event)) {
-	          inst._wrapperState.listeners.push(ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes[event], mediaEvents[event], node));
+	          inst._wrapperState.listeners.push(ReactBrowserEventEmitter.trapBubbledEvent(event, mediaEvents[event], node));
 	        }
 	      }
 	      break;
 	    case 'source':
-	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topError, 'error', node)];
+	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node)];
 	      break;
 	    case 'img':
-	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topError, 'error', node), ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topLoad, 'load', node)];
+	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node), ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node)];
 	      break;
 	    case 'form':
-	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topReset, 'reset', node), ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topSubmit, 'submit', node)];
+	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node), ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node)];
 	      break;
 	    case 'input':
 	    case 'select':
 	    case 'textarea':
-	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent(EventConstants.topLevelTypes.topInvalid, 'invalid', node)];
+	      inst._wrapperState.listeners = [ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node)];
 	      break;
 	  }
 	}
@@ -16271,7 +16285,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  'wbr': true
 	};
 
-	// NOTE: menuitem's close tag should be omitted, but that causes problems.
 	var newlineEatingTags = {
 	  'listing': true,
 	  'pre': true,
@@ -16379,9 +16392,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	          listeners: null
 	        };
 	        transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
-	        break;
-	      case 'button':
-	        props = ReactDOMButton.getHostProps(this, props, hostParent);
 	        break;
 	      case 'input':
 	        ReactDOMInput.mountWrapper(this, props, hostParent);
@@ -16686,10 +16696,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var nextProps = this._currentElement.props;
 
 	    switch (this._tag) {
-	      case 'button':
-	        lastProps = ReactDOMButton.getHostProps(this, lastProps);
-	        nextProps = ReactDOMButton.getHostProps(this, nextProps);
-	        break;
 	      case 'input':
 	        lastProps = ReactDOMInput.getHostProps(this, lastProps);
 	        nextProps = ReactDOMInput.getHostProps(this, nextProps);
@@ -16959,7 +16965,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMComponent;
 
 /***/ },
-/* 122 */
+/* 121 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -16970,14 +16976,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule AutoFocusUtils
 	 */
 
 	'use strict';
 
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 
-	var focusNode = __webpack_require__(123);
+	var focusNode = __webpack_require__(122);
 
 	var AutoFocusUtils = {
 	  focusDOMComponent: function focusDOMComponent() {
@@ -16988,7 +16993,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = AutoFocusUtils;
 
 /***/ },
-/* 123 */
+/* 122 */
 /***/ function(module, exports) {
 
 	/**
@@ -17019,7 +17024,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = focusNode;
 
 /***/ },
-/* 124 */
+/* 123 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17030,19 +17035,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule CSSPropertyOperations
 	 */
 
 	'use strict';
 
-	var CSSProperty = __webpack_require__(125);
-	var ExecutionEnvironment = __webpack_require__(82);
+	var CSSProperty = __webpack_require__(124);
+	var ExecutionEnvironment = __webpack_require__(81);
 	var ReactInstrumentation = __webpack_require__(95);
 
-	var camelizeStyleName = __webpack_require__(126);
-	var dangerousStyleValue = __webpack_require__(128);
-	var hyphenateStyleName = __webpack_require__(129);
-	var memoizeStringOnly = __webpack_require__(131);
+	var camelizeStyleName = __webpack_require__(125);
+	var dangerousStyleValue = __webpack_require__(127);
+	var hyphenateStyleName = __webpack_require__(128);
+	var memoizeStringOnly = __webpack_require__(130);
 	var warning = __webpack_require__(11);
 
 	var processStyleName = memoizeStringOnly(function (styleName) {
@@ -17192,7 +17196,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	   */
 	  setValueForStyles: function setValueForStyles(node, styles, component) {
 	    if (false) {
-	      ReactInstrumentation.debugTool.onHostOperation(component._debugID, 'update styles', styles);
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: component._debugID,
+	        type: 'update styles',
+	        payload: styles
+	      });
 	    }
 
 	    var style = node.style;
@@ -17229,7 +17237,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CSSPropertyOperations;
 
 /***/ },
-/* 125 */
+/* 124 */
 /***/ function(module, exports) {
 
 	/**
@@ -17240,7 +17248,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule CSSProperty
 	 */
 
 	'use strict';
@@ -17382,7 +17389,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = CSSProperty;
 
 /***/ },
-/* 126 */
+/* 125 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17398,7 +17405,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 
-	var camelize = __webpack_require__(127);
+	var camelize = __webpack_require__(126);
 
 	var msPattern = /^-ms-/;
 
@@ -17426,7 +17433,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = camelizeStyleName;
 
 /***/ },
-/* 127 */
+/* 126 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -17462,7 +17469,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = camelize;
 
 /***/ },
-/* 128 */
+/* 127 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17473,12 +17480,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule dangerousStyleValue
 	 */
 
 	'use strict';
 
-	var CSSProperty = __webpack_require__(125);
+	var CSSProperty = __webpack_require__(124);
 	var warning = __webpack_require__(11);
 
 	var isUnitlessNumber = CSSProperty.isUnitlessNumber;
@@ -17546,7 +17552,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = dangerousStyleValue;
 
 /***/ },
-/* 129 */
+/* 128 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17562,7 +17568,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict';
 
-	var hyphenate = __webpack_require__(130);
+	var hyphenate = __webpack_require__(129);
 
 	var msPattern = /^ms-/;
 
@@ -17589,7 +17595,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = hyphenateStyleName;
 
 /***/ },
-/* 130 */
+/* 129 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -17626,7 +17632,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = hyphenate;
 
 /***/ },
-/* 131 */
+/* 130 */
 /***/ function(module, exports) {
 
 	/**
@@ -17660,7 +17666,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = memoizeStringOnly;
 
 /***/ },
-/* 132 */
+/* 131 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17671,16 +17677,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule DOMPropertyOperations
 	 */
 
 	'use strict';
 
-	var DOMProperty = __webpack_require__(70);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var DOMProperty = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactInstrumentation = __webpack_require__(95);
 
-	var quoteAttributeValueForBrowser = __webpack_require__(133);
+	var quoteAttributeValueForBrowser = __webpack_require__(132);
 	var warning = __webpack_require__(11);
 
 	var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + DOMProperty.ATTRIBUTE_NAME_START_CHAR + '][' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
@@ -17816,7 +17821,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (false) {
 	      var payload = {};
 	      payload[name] = value;
-	      ReactInstrumentation.debugTool.onHostOperation(ReactDOMComponentTree.getInstanceFromNode(node)._debugID, 'update attribute', payload);
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+	        type: 'update attribute',
+	        payload: payload
+	      });
 	    }
 	  },
 
@@ -17833,7 +17842,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (false) {
 	      var payload = {};
 	      payload[name] = value;
-	      ReactInstrumentation.debugTool.onHostOperation(ReactDOMComponentTree.getInstanceFromNode(node)._debugID, 'update attribute', payload);
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+	        type: 'update attribute',
+	        payload: payload
+	      });
 	    }
 	  },
 
@@ -17846,7 +17859,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  deleteValueForAttribute: function deleteValueForAttribute(node, name) {
 	    node.removeAttribute(name);
 	    if (false) {
-	      ReactInstrumentation.debugTool.onHostOperation(ReactDOMComponentTree.getInstanceFromNode(node)._debugID, 'remove attribute', name);
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+	        type: 'remove attribute',
+	        payload: name
+	      });
 	    }
 	  },
 
@@ -17877,7 +17894,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    if (false) {
-	      ReactInstrumentation.debugTool.onHostOperation(ReactDOMComponentTree.getInstanceFromNode(node)._debugID, 'remove attribute', name);
+	      ReactInstrumentation.debugTool.onHostOperation({
+	        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+	        type: 'remove attribute',
+	        payload: name
+	      });
 	    }
 	  }
 
@@ -17886,7 +17907,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = DOMPropertyOperations;
 
 /***/ },
-/* 133 */
+/* 132 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17897,7 +17918,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule quoteAttributeValueForBrowser
 	 */
 
 	'use strict';
@@ -17917,7 +17937,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = quoteAttributeValueForBrowser;
 
 /***/ },
-/* 134 */
+/* 133 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -17928,19 +17948,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactBrowserEventEmitter
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var EventConstants = __webpack_require__(74);
-	var EventPluginRegistry = __webpack_require__(77);
-	var ReactEventEmitterMixin = __webpack_require__(135);
+	var EventPluginRegistry = __webpack_require__(76);
+	var ReactEventEmitterMixin = __webpack_require__(134);
 	var ViewportMetrics = __webpack_require__(104);
 
-	var getVendorPrefixedEventName = __webpack_require__(136);
+	var getVendorPrefixedEventName = __webpack_require__(135);
 	var isEventSupported = __webpack_require__(98);
 
 	/**
@@ -18159,42 +18177,41 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var isListening = getListeningForDocument(mountAt);
 	    var dependencies = EventPluginRegistry.registrationNameDependencies[registrationName];
 
-	    var topLevelTypes = EventConstants.topLevelTypes;
 	    for (var i = 0; i < dependencies.length; i++) {
 	      var dependency = dependencies[i];
 	      if (!(isListening.hasOwnProperty(dependency) && isListening[dependency])) {
-	        if (dependency === topLevelTypes.topWheel) {
+	        if (dependency === 'topWheel') {
 	          if (isEventSupported('wheel')) {
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topWheel, 'wheel', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'wheel', mountAt);
 	          } else if (isEventSupported('mousewheel')) {
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topWheel, 'mousewheel', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'mousewheel', mountAt);
 	          } else {
 	            // Firefox needs to capture a different mouse scroll event.
 	            // @see http://www.quirksmode.org/dom/events/tests/scroll.html
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topWheel, 'DOMMouseScroll', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topWheel', 'DOMMouseScroll', mountAt);
 	          }
-	        } else if (dependency === topLevelTypes.topScroll) {
+	        } else if (dependency === 'topScroll') {
 
 	          if (isEventSupported('scroll', true)) {
-	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(topLevelTypes.topScroll, 'scroll', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topScroll', 'scroll', mountAt);
 	          } else {
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topScroll, 'scroll', ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topScroll', 'scroll', ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE);
 	          }
-	        } else if (dependency === topLevelTypes.topFocus || dependency === topLevelTypes.topBlur) {
+	        } else if (dependency === 'topFocus' || dependency === 'topBlur') {
 
 	          if (isEventSupported('focus', true)) {
-	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(topLevelTypes.topFocus, 'focus', mountAt);
-	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(topLevelTypes.topBlur, 'blur', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topFocus', 'focus', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent('topBlur', 'blur', mountAt);
 	          } else if (isEventSupported('focusin')) {
 	            // IE has `focusin` and `focusout` events which bubble.
 	            // @see http://www.quirksmode.org/blog/archives/2008/04/delegating_the.html
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topFocus, 'focusin', mountAt);
-	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(topLevelTypes.topBlur, 'focusout', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topFocus', 'focusin', mountAt);
+	            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent('topBlur', 'focusout', mountAt);
 	          }
 
 	          // to make sure blur and focus event listeners are only attached once
-	          isListening[topLevelTypes.topBlur] = true;
-	          isListening[topLevelTypes.topFocus] = true;
+	          isListening.topBlur = true;
+	          isListening.topFocus = true;
 	        } else if (topEventMapping.hasOwnProperty(dependency)) {
 	          ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(dependency, topEventMapping[dependency], mountAt);
 	        }
@@ -18252,7 +18269,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactBrowserEventEmitter;
 
 /***/ },
-/* 135 */
+/* 134 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -18263,12 +18280,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactEventEmitterMixin
 	 */
 
 	'use strict';
 
-	var EventPluginHub = __webpack_require__(76);
+	var EventPluginHub = __webpack_require__(75);
 
 	function runEventQueueInBatch(events) {
 	  EventPluginHub.enqueueEvents(events);
@@ -18290,7 +18306,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactEventEmitterMixin;
 
 /***/ },
-/* 136 */
+/* 135 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -18301,12 +18317,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getVendorPrefixedEventName
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
 	/**
 	 * Generate a mapping of standard vendor prefixes using the defined style property and event name.
@@ -18396,7 +18411,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getVendorPrefixedEventName;
 
 /***/ },
-/* 137 */
+/* 136 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -18407,102 +18422,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMButton
 	 */
 
 	'use strict';
 
-	var DisabledInputUtils = __webpack_require__(138);
-
-	/**
-	 * Implements a <button> host component that does not receive mouse events
-	 * when `disabled` is set.
-	 */
-	var ReactDOMButton = {
-	  getHostProps: DisabledInputUtils.getHostProps
-	};
-
-	module.exports = ReactDOMButton;
-
-/***/ },
-/* 138 */
-/***/ function(module, exports) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule DisabledInputUtils
-	 */
-
-	'use strict';
-
-	var disableableMouseListenerNames = {
-	  onClick: true,
-	  onDoubleClick: true,
-	  onMouseDown: true,
-	  onMouseMove: true,
-	  onMouseUp: true,
-
-	  onClickCapture: true,
-	  onDoubleClickCapture: true,
-	  onMouseDownCapture: true,
-	  onMouseMoveCapture: true,
-	  onMouseUpCapture: true
-	};
-
-	/**
-	 * Implements a host component that does not receive mouse events
-	 * when `disabled` is set.
-	 */
-	var DisabledInputUtils = {
-	  getHostProps: function getHostProps(inst, props) {
-	    if (!props.disabled) {
-	      return props;
-	    }
-
-	    // Copy the props, except the mouse listeners
-	    var hostProps = {};
-	    for (var key in props) {
-	      if (!disableableMouseListenerNames[key] && props.hasOwnProperty(key)) {
-	        hostProps[key] = props[key];
-	      }
-	    }
-
-	    return hostProps;
-	  }
-	};
-
-	module.exports = DisabledInputUtils;
-
-/***/ },
-/* 139 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule ReactDOMInput
-	 */
-
-	'use strict';
-
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
-	var DisabledInputUtils = __webpack_require__(138);
-	var DOMPropertyOperations = __webpack_require__(132);
-	var LinkedValueUtils = __webpack_require__(140);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var DOMPropertyOperations = __webpack_require__(131);
+	var LinkedValueUtils = __webpack_require__(137);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactUpdates = __webpack_require__(89);
 
 	var invariant = __webpack_require__(8);
@@ -18559,7 +18488,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // in corner cases such as min or max deriving from value, e.g. Issue #7170)
 	      min: undefined,
 	      max: undefined
-	    }, DisabledInputUtils.getHostProps(inst, props), {
+	    }, props, {
 	      defaultChecked: undefined,
 	      defaultValue: undefined,
 	      value: value != null ? value : inst._wrapperState.initialValue,
@@ -18754,7 +18683,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMInput;
 
 /***/ },
-/* 140 */
+/* 137 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -18765,16 +18694,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule LinkedValueUtils
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var ReactPropTypes = __webpack_require__(27);
-	var ReactPropTypeLocations = __webpack_require__(22);
-	var ReactPropTypesSecret = __webpack_require__(28);
+	var React = __webpack_require__(3);
+	var ReactPropTypesSecret = __webpack_require__(138);
 
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
@@ -18815,7 +18742,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    return new Error('You provided a `checked` prop to a form field without an ' + '`onChange` handler. This will render a read-only field. If ' + 'the field should be mutable use `defaultChecked`. Otherwise, ' + 'set either `onChange` or `readOnly`.');
 	  },
-	  onChange: ReactPropTypes.func
+	  onChange: React.PropTypes.func
 	};
 
 	var loggedTypeFailures = {};
@@ -18837,7 +18764,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  checkPropTypes: function checkPropTypes(tagName, props, owner) {
 	    for (var propName in propTypes) {
 	      if (propTypes.hasOwnProperty(propName)) {
-	        var error = propTypes[propName](props, propName, tagName, ReactPropTypeLocations.prop, null, ReactPropTypesSecret);
+	        var error = propTypes[propName](props, propName, tagName, 'prop', null, ReactPropTypesSecret);
 	      }
 	      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
 	        // Only monitor this failure once because there tends to be a lot of the
@@ -18895,7 +18822,28 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = LinkedValueUtils;
 
 /***/ },
-/* 141 */
+/* 138 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+
+	module.exports = ReactPropTypesSecret;
+
+/***/ },
+/* 139 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -18906,16 +18854,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMOption
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var ReactChildren = __webpack_require__(5);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactDOMSelect = __webpack_require__(142);
+	var React = __webpack_require__(3);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactDOMSelect = __webpack_require__(140);
 
 	var warning = __webpack_require__(11);
 	var didWarnInvalidOptionChildren = false;
@@ -18925,7 +18872,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Flatten children and warn if they aren't strings or numbers;
 	  // invalid types are ignored.
-	  ReactChildren.forEach(children, function (child) {
+	  React.Children.forEach(children, function (child) {
 	    if (child == null) {
 	      return;
 	    }
@@ -19023,7 +18970,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMOption;
 
 /***/ },
-/* 142 */
+/* 140 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -19034,16 +18981,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMSelect
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var DisabledInputUtils = __webpack_require__(138);
-	var LinkedValueUtils = __webpack_require__(140);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var LinkedValueUtils = __webpack_require__(137);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactUpdates = __webpack_require__(89);
 
 	var warning = __webpack_require__(11);
@@ -19157,7 +19102,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	var ReactDOMSelect = {
 	  getHostProps: function getHostProps(inst, props) {
-	    return _assign({}, DisabledInputUtils.getHostProps(inst, props), {
+	    return _assign({}, props, {
 	      onChange: inst._wrapperState.onChange,
 	      value: undefined
 	    });
@@ -19229,7 +19174,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMSelect;
 
 /***/ },
-/* 143 */
+/* 141 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -19240,17 +19185,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMTextarea
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
-	var DisabledInputUtils = __webpack_require__(138);
-	var LinkedValueUtils = __webpack_require__(140);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var LinkedValueUtils = __webpack_require__(137);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactUpdates = __webpack_require__(89);
 
 	var invariant = __webpack_require__(8);
@@ -19290,7 +19233,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // to only set the value if/when the value differs from the node value (which would
 	    // completely solve this IE9 bug), but Sebastian+Ben seemed to like this solution.
 	    // The value can be a boolean or object so that's why it's forced to be a string.
-	    var hostProps = _assign({}, DisabledInputUtils.getHostProps(inst, props), {
+	    var hostProps = _assign({}, props, {
 	      value: undefined,
 	      defaultValue: undefined,
 	      children: '' + inst._wrapperState.initialValue,
@@ -19389,7 +19332,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMTextarea;
 
 /***/ },
-/* 144 */
+/* 142 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -19400,24 +19343,22 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactMultiChild
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var ReactComponentEnvironment = __webpack_require__(145);
-	var ReactInstanceMap = __webpack_require__(146);
+	var ReactComponentEnvironment = __webpack_require__(143);
+	var ReactInstanceMap = __webpack_require__(144);
 	var ReactInstrumentation = __webpack_require__(95);
-	var ReactMultiChildUpdateTypes = __webpack_require__(119);
 
 	var ReactCurrentOwner = __webpack_require__(10);
 	var ReactReconciler = __webpack_require__(92);
-	var ReactChildReconciler = __webpack_require__(147);
+	var ReactChildReconciler = __webpack_require__(145);
 
 	var emptyFunction = __webpack_require__(12);
-	var flattenChildren = __webpack_require__(158);
+	var flattenChildren = __webpack_require__(160);
 	var invariant = __webpack_require__(8);
 
 	/**
@@ -19430,7 +19371,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function makeInsertMarkup(markup, afterNode, toIndex) {
 	  // NOTE: Null values reduce hidden classes.
 	  return {
-	    type: ReactMultiChildUpdateTypes.INSERT_MARKUP,
+	    type: 'INSERT_MARKUP',
 	    content: markup,
 	    fromIndex: null,
 	    fromNode: null,
@@ -19449,7 +19390,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function makeMove(child, afterNode, toIndex) {
 	  // NOTE: Null values reduce hidden classes.
 	  return {
-	    type: ReactMultiChildUpdateTypes.MOVE_EXISTING,
+	    type: 'MOVE_EXISTING',
 	    content: null,
 	    fromIndex: child._mountIndex,
 	    fromNode: ReactReconciler.getHostNode(child),
@@ -19467,7 +19408,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function makeRemove(child, node) {
 	  // NOTE: Null values reduce hidden classes.
 	  return {
-	    type: ReactMultiChildUpdateTypes.REMOVE_NODE,
+	    type: 'REMOVE_NODE',
 	    content: null,
 	    fromIndex: child._mountIndex,
 	    fromNode: node,
@@ -19485,7 +19426,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function makeSetMarkup(markup) {
 	  // NOTE: Null values reduce hidden classes.
 	  return {
-	    type: ReactMultiChildUpdateTypes.SET_MARKUP,
+	    type: 'SET_MARKUP',
 	    content: markup,
 	    fromIndex: null,
 	    fromNode: null,
@@ -19503,7 +19444,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function makeTextContent(textContent) {
 	  // NOTE: Null values reduce hidden classes.
 	  return {
-	    type: ReactMultiChildUpdateTypes.TEXT_CONTENT,
+	    type: 'TEXT_CONTENT',
 	    content: textContent,
 	    fromIndex: null,
 	    fromNode: null,
@@ -19845,7 +19786,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactMultiChild;
 
 /***/ },
-/* 145 */
+/* 143 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -19856,12 +19797,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactComponentEnvironment
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
 
@@ -19895,7 +19836,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactComponentEnvironment;
 
 /***/ },
-/* 146 */
+/* 144 */
 /***/ function(module, exports) {
 
 	/**
@@ -19906,7 +19847,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactInstanceMap
 	 */
 
 	'use strict';
@@ -19948,7 +19888,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactInstanceMap;
 
 /***/ },
-/* 147 */
+/* 145 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
@@ -19959,17 +19899,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactChildReconciler
 	 */
 
 	'use strict';
 
 	var ReactReconciler = __webpack_require__(92);
 
-	var instantiateReactComponent = __webpack_require__(149);
-	var KeyEscapeUtils = __webpack_require__(16);
-	var shouldUpdateReactComponent = __webpack_require__(155);
-	var traverseAllChildren = __webpack_require__(14);
+	var instantiateReactComponent = __webpack_require__(147);
+	var KeyEscapeUtils = __webpack_require__(155);
+	var shouldUpdateReactComponent = __webpack_require__(151);
+	var traverseAllChildren = __webpack_require__(156);
 	var warning = __webpack_require__(11);
 
 	var ReactComponentTreeHook;
@@ -19980,7 +19919,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // https://github.com/facebook/react/issues/7240
 	  // Remove the inline requires when we don't need them anymore:
 	  // https://github.com/facebook/react/pull/7178
-	  ReactComponentTreeHook = __webpack_require__(153);
+	  ReactComponentTreeHook = __webpack_require__(159);
 	}
 
 	function instantiateChild(childInstances, child, name, selfDebugID) {
@@ -19988,7 +19927,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var keyUnique = childInstances[name] === undefined;
 	  if (false) {
 	    if (!ReactComponentTreeHook) {
-	      ReactComponentTreeHook = require('./ReactComponentTreeHook');
+	      ReactComponentTreeHook = require('react/lib/ReactComponentTreeHook');
 	    }
 	    if (!keyUnique) {
 	      process.env.NODE_ENV !== 'production' ? warning(false, 'flattenChildren(...): Encountered two children with the same key, ' + '`%s`. Child keys must be unique; when two children share a key, only ' + 'the first child will be used.%s', KeyEscapeUtils.unescape(name), ReactComponentTreeHook.getStackAddendumByID(selfDebugID)) : void 0;
@@ -20105,10 +20044,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	module.exports = ReactChildReconciler;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(148)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(146)))
 
 /***/ },
-/* 148 */
+/* 146 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -20294,7 +20233,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 149 */
+/* 147 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -20305,20 +20244,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule instantiateReactComponent
 	 */
 
 	'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
-	var ReactCompositeComponent = __webpack_require__(150);
-	var ReactEmptyComponent = __webpack_require__(156);
-	var ReactHostComponent = __webpack_require__(157);
+	var ReactCompositeComponent = __webpack_require__(148);
+	var ReactEmptyComponent = __webpack_require__(152);
+	var ReactHostComponent = __webpack_require__(153);
 
+	var getNextDebugID = __webpack_require__(154);
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
 
@@ -20326,7 +20265,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var ReactCompositeComponentWrapper = function ReactCompositeComponentWrapper(element) {
 	  this.construct(element);
 	};
-	_assign(ReactCompositeComponentWrapper.prototype, ReactCompositeComponent.Mixin, {
+	_assign(ReactCompositeComponentWrapper.prototype, ReactCompositeComponent, {
 	  _instantiateReactComponent: instantiateReactComponent
 	});
 
@@ -20350,8 +20289,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	function isInternalComponentType(type) {
 	  return typeof type === 'function' && typeof type.prototype !== 'undefined' && typeof type.prototype.mountComponent === 'function' && typeof type.prototype.receiveComponent === 'function';
 	}
-
-	var nextDebugID = 1;
 
 	/**
 	 * Given a ReactNode, create an instance that will actually be mounted.
@@ -20403,7 +20340,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  instance._mountImage = null;
 
 	  if (false) {
-	    instance._debugID = shouldHaveDebugID ? nextDebugID++ : 0;
+	    instance._debugID = shouldHaveDebugID ? getNextDebugID() : 0;
 	  }
 
 	  // Internal instances should fully constructed at this point, so they should
@@ -20420,7 +20357,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = instantiateReactComponent;
 
 /***/ },
-/* 150 */
+/* 148 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -20431,31 +20368,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactCompositeComponent
 	 */
 
 	'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
-	var ReactComponentEnvironment = __webpack_require__(145);
+	var React = __webpack_require__(3);
+	var ReactComponentEnvironment = __webpack_require__(143);
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactElement = __webpack_require__(9);
-	var ReactErrorUtils = __webpack_require__(79);
-	var ReactInstanceMap = __webpack_require__(146);
+	var ReactErrorUtils = __webpack_require__(78);
+	var ReactInstanceMap = __webpack_require__(144);
 	var ReactInstrumentation = __webpack_require__(95);
-	var ReactNodeTypes = __webpack_require__(151);
-	var ReactPropTypeLocations = __webpack_require__(22);
+	var ReactNodeTypes = __webpack_require__(149);
 	var ReactReconciler = __webpack_require__(92);
 
-	var checkReactTypeSpec = __webpack_require__(152);
-	var emptyObject = __webpack_require__(19);
+	if (false) {
+	  var checkReactTypeSpec = require('./checkReactTypeSpec');
+	}
+
+	var emptyObject = __webpack_require__(20);
 	var invariant = __webpack_require__(8);
-	var shallowEqual = __webpack_require__(154);
-	var shouldUpdateReactComponent = __webpack_require__(155);
+	var shallowEqual = __webpack_require__(150);
+	var shouldUpdateReactComponent = __webpack_require__(151);
 	var warning = __webpack_require__(11);
 
 	var CompositeTypes = {
@@ -20474,7 +20412,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function warnIfInvalidElement(Component, element) {
 	  if (false) {
-	    process.env.NODE_ENV !== 'production' ? warning(element === null || element === false || ReactElement.isValidElement(element), '%s(...): A valid React element (or null) must be returned. You may have ' + 'returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : void 0;
+	    process.env.NODE_ENV !== 'production' ? warning(element === null || element === false || React.isValidElement(element), '%s(...): A valid React element (or null) must be returned. You may have ' + 'returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : void 0;
 	    process.env.NODE_ENV !== 'production' ? warning(!Component.childContextTypes, '%s(...): childContextTypes cannot be defined on a functional component.', Component.displayName || Component.name || 'Component') : void 0;
 	  }
 	}
@@ -20542,7 +20480,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/**
 	 * @lends {ReactCompositeComponent.prototype}
 	 */
-	var ReactCompositeComponentMixin = {
+	var ReactCompositeComponent = {
 
 	  /**
 	   * Base constructor for all composite component.
@@ -20618,7 +20556,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (!doConstruct && (inst == null || inst.render == null)) {
 	      renderedElement = inst;
 	      warnIfInvalidElement(Component, renderedElement);
-	      !(inst === null || inst === false || ReactElement.isValidElement(inst)) ?  false ? invariant(false, '%s(...): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : _prodInvariant('105', Component.displayName || Component.name || 'Component') : void 0;
+	      !(inst === null || inst === false || React.isValidElement(inst)) ?  false ? invariant(false, '%s(...): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', Component.displayName || Component.name || 'Component') : _prodInvariant('105', Component.displayName || Component.name || 'Component') : void 0;
 	      inst = new StatelessComponent(Component);
 	      this._compositeType = CompositeTypes.StatelessFunctional;
 	    } else {
@@ -20908,7 +20846,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (false) {
 	      var Component = this._currentElement.type;
 	      if (Component.contextTypes) {
-	        this._checkContextTypes(Component.contextTypes, maskedContext, ReactPropTypeLocations.context);
+	        this._checkContextTypes(Component.contextTypes, maskedContext, 'context');
 	      }
 	    }
 	    return maskedContext;
@@ -20940,7 +20878,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (childContext) {
 	      !(_typeof(Component.childContextTypes) === 'object') ?  false ? invariant(false, '%s.getChildContext(): childContextTypes must be defined in order to use getChildContext().', this.getName() || 'ReactCompositeComponent') : _prodInvariant('107', this.getName() || 'ReactCompositeComponent') : void 0;
 	      if (false) {
-	        this._checkContextTypes(Component.childContextTypes, childContext, ReactPropTypeLocations.childContext);
+	        this._checkContextTypes(Component.childContextTypes, childContext, 'childContext');
 	      }
 	      for (var name in childContext) {
 	        !(name in Component.childContextTypes) ?  false ? invariant(false, '%s.getChildContext(): key "%s" is not defined in childContextTypes.', this.getName() || 'ReactCompositeComponent', name) : _prodInvariant('108', this.getName() || 'ReactCompositeComponent', name) : void 0;
@@ -20959,7 +20897,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * @private
 	   */
 	  _checkContextTypes: function _checkContextTypes(typeSpecs, values, location) {
-	    checkReactTypeSpec(typeSpecs, values, location, this.getName(), null, this._debugID);
+	    if (false) {
+	      checkReactTypeSpec(typeSpecs, values, location, this.getName(), null, this._debugID);
+	    }
 	  },
 
 	  receiveComponent: function receiveComponent(nextElement, transaction, nextContext) {
@@ -21213,48 +21153,48 @@ return /******/ (function(modules) { // webpackBootstrap
 	   */
 	  _renderValidatedComponentWithoutOwnerOrContext: function _renderValidatedComponentWithoutOwnerOrContext() {
 	    var inst = this._instance;
-	    var renderedComponent;
+	    var renderedElement;
 
 	    if (false) {
-	      renderedComponent = measureLifeCyclePerf(function () {
+	      renderedElement = measureLifeCyclePerf(function () {
 	        return inst.render();
 	      }, this._debugID, 'render');
 	    } else {
-	      renderedComponent = inst.render();
+	      renderedElement = inst.render();
 	    }
 
 	    if (false) {
 	      // We allow auto-mocks to proceed as if they're returning null.
-	      if (renderedComponent === undefined && inst.render._isMockFunction) {
+	      if (renderedElement === undefined && inst.render._isMockFunction) {
 	        // This is probably bad practice. Consider warning here and
 	        // deprecating this convenience.
-	        renderedComponent = null;
+	        renderedElement = null;
 	      }
 	    }
 
-	    return renderedComponent;
+	    return renderedElement;
 	  },
 
 	  /**
 	   * @private
 	   */
 	  _renderValidatedComponent: function _renderValidatedComponent() {
-	    var renderedComponent;
+	    var renderedElement;
 	    if (('production') !== 'production' || this._compositeType !== CompositeTypes.StatelessFunctional) {
 	      ReactCurrentOwner.current = this;
 	      try {
-	        renderedComponent = this._renderValidatedComponentWithoutOwnerOrContext();
+	        renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
 	      } finally {
 	        ReactCurrentOwner.current = null;
 	      }
 	    } else {
-	      renderedComponent = this._renderValidatedComponentWithoutOwnerOrContext();
+	      renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
 	    }
 	    !(
 	    // TODO: An `isValidNode` function would probably be more appropriate
-	    renderedComponent === null || renderedComponent === false || ReactElement.isValidElement(renderedComponent)) ?  false ? invariant(false, '%s.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', this.getName() || 'ReactCompositeComponent') : _prodInvariant('109', this.getName() || 'ReactCompositeComponent') : void 0;
+	    renderedElement === null || renderedElement === false || React.isValidElement(renderedElement)) ?  false ? invariant(false, '%s.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.', this.getName() || 'ReactCompositeComponent') : _prodInvariant('109', this.getName() || 'ReactCompositeComponent') : void 0;
 
-	    return renderedComponent;
+	    return renderedElement;
 	  },
 
 	  /**
@@ -21322,16 +21262,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	};
 
-	var ReactCompositeComponent = {
-
-	  Mixin: ReactCompositeComponentMixin
-
-	};
-
 	module.exports = ReactCompositeComponent;
 
 /***/ },
-/* 151 */
+/* 149 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -21342,15 +21276,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactNodeTypes
 	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var ReactElement = __webpack_require__(9);
+	var React = __webpack_require__(3);
 
 	var invariant = __webpack_require__(8);
 
@@ -21362,7 +21295,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  getType: function getType(node) {
 	    if (node === null || node === false) {
 	      return ReactNodeTypes.EMPTY;
-	    } else if (ReactElement.isValidElement(node)) {
+	    } else if (React.isValidElement(node)) {
 	      if (typeof node.type === 'function') {
 	        return ReactNodeTypes.COMPOSITE;
 	      } else {
@@ -21376,450 +21309,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactNodeTypes;
 
 /***/ },
-/* 152 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule checkReactTypeSpec
-	 */
-
-	'use strict';
-
-	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-	var _prodInvariant = __webpack_require__(7);
-
-	var ReactPropTypeLocationNames = __webpack_require__(24);
-	var ReactPropTypesSecret = __webpack_require__(28);
-
-	var invariant = __webpack_require__(8);
-	var warning = __webpack_require__(11);
-
-	var ReactComponentTreeHook;
-
-	if (typeof process !== 'undefined' && process.env && ('production') === 'test') {
-	  // Temporary hack.
-	  // Inline requires don't work well with Jest:
-	  // https://github.com/facebook/react/issues/7240
-	  // Remove the inline requires when we don't need them anymore:
-	  // https://github.com/facebook/react/pull/7178
-	  ReactComponentTreeHook = __webpack_require__(153);
-	}
-
-	var loggedTypeFailures = {};
-
-	/**
-	 * Assert that the values match with the type specs.
-	 * Error messages are memorized and will only be shown once.
-	 *
-	 * @param {object} typeSpecs Map of name to a ReactPropType
-	 * @param {object} values Runtime values that need to be type-checked
-	 * @param {string} location e.g. "prop", "context", "child context"
-	 * @param {string} componentName Name of the component for error messages.
-	 * @param {?object} element The React element that is being type-checked
-	 * @param {?number} debugID The React component instance that is being type-checked
-	 * @private
-	 */
-	function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
-	  for (var typeSpecName in typeSpecs) {
-	    if (typeSpecs.hasOwnProperty(typeSpecName)) {
-	      var error;
-	      // Prop type validation may throw. In case they do, we don't want to
-	      // fail the render phase where it didn't fail before. So we log it.
-	      // After these have been cleaned up, we'll let them throw.
-	      try {
-	        // This is intentionally an invariant that gets caught. It's the same
-	        // behavior as without this statement except with a better message.
-	        !(typeof typeSpecs[typeSpecName] === 'function') ?  false ? invariant(false, '%s: %s type `%s` is invalid; it must be a function, usually from React.PropTypes.', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : _prodInvariant('84', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName) : void 0;
-	        error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
-	      } catch (ex) {
-	        error = ex;
-	      }
-	       false ? warning(!error || error instanceof Error, '%s: type specification of %s `%s` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a %s. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).', componentName || 'React class', ReactPropTypeLocationNames[location], typeSpecName, typeof error === 'undefined' ? 'undefined' : _typeof(error)) : void 0;
-	      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
-	        // Only monitor this failure once because there tends to be a lot of the
-	        // same error.
-	        loggedTypeFailures[error.message] = true;
-
-	        var componentStackInfo = '';
-
-	        if (false) {
-	          if (!ReactComponentTreeHook) {
-	            ReactComponentTreeHook = require('./ReactComponentTreeHook');
-	          }
-	          if (debugID !== null) {
-	            componentStackInfo = ReactComponentTreeHook.getStackAddendumByID(debugID);
-	          } else if (element !== null) {
-	            componentStackInfo = ReactComponentTreeHook.getCurrentStackAddendum(element);
-	          }
-	        }
-
-	         false ? warning(false, 'Failed %s type: %s%s', location, error.message, componentStackInfo) : void 0;
-	      }
-	    }
-	  }
-	}
-
-	module.exports = checkReactTypeSpec;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(148)))
-
-/***/ },
-/* 153 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/**
-	 * Copyright 2016-present, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 * @providesModule ReactComponentTreeHook
-	 */
-
-	'use strict';
-
-	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-	var _prodInvariant = __webpack_require__(7);
-
-	var ReactCurrentOwner = __webpack_require__(10);
-
-	var invariant = __webpack_require__(8);
-	var warning = __webpack_require__(11);
-
-	function isNative(fn) {
-	  // Based on isNative() from Lodash
-	  var funcToString = Function.prototype.toString;
-	  var hasOwnProperty = Object.prototype.hasOwnProperty;
-	  var reIsNative = RegExp('^' + funcToString
-	  // Take an example native function source for comparison
-	  .call(hasOwnProperty)
-	  // Strip regex characters so we can use it for regex
-	  .replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
-	  // Remove hasOwnProperty from the template to make it generic
-	  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
-	  try {
-	    var source = funcToString.call(fn);
-	    return reIsNative.test(source);
-	  } catch (err) {
-	    return false;
-	  }
-	}
-
-	var canUseCollections =
-	// Array.from
-	typeof Array.from === 'function' &&
-	// Map
-	typeof Map === 'function' && isNative(Map) &&
-	// Map.prototype.keys
-	Map.prototype != null && typeof Map.prototype.keys === 'function' && isNative(Map.prototype.keys) &&
-	// Set
-	typeof Set === 'function' && isNative(Set) &&
-	// Set.prototype.keys
-	Set.prototype != null && typeof Set.prototype.keys === 'function' && isNative(Set.prototype.keys);
-
-	var itemMap;
-	var rootIDSet;
-
-	var itemByKey;
-	var rootByKey;
-
-	if (canUseCollections) {
-	  itemMap = new Map();
-	  rootIDSet = new Set();
-	} else {
-	  itemByKey = {};
-	  rootByKey = {};
-	}
-
-	var unmountedIDs = [];
-
-	// Use non-numeric keys to prevent V8 performance issues:
-	// https://github.com/facebook/react/pull/7232
-	function getKeyFromID(id) {
-	  return '.' + id;
-	}
-	function getIDFromKey(key) {
-	  return parseInt(key.substr(1), 10);
-	}
-
-	function get(id) {
-	  if (canUseCollections) {
-	    return itemMap.get(id);
-	  } else {
-	    var key = getKeyFromID(id);
-	    return itemByKey[key];
-	  }
-	}
-
-	function remove(id) {
-	  if (canUseCollections) {
-	    itemMap['delete'](id);
-	  } else {
-	    var key = getKeyFromID(id);
-	    delete itemByKey[key];
-	  }
-	}
-
-	function create(id, element, parentID) {
-	  var item = {
-	    element: element,
-	    parentID: parentID,
-	    text: null,
-	    childIDs: [],
-	    isMounted: false,
-	    updateCount: 0
-	  };
-
-	  if (canUseCollections) {
-	    itemMap.set(id, item);
-	  } else {
-	    var key = getKeyFromID(id);
-	    itemByKey[key] = item;
-	  }
-	}
-
-	function addRoot(id) {
-	  if (canUseCollections) {
-	    rootIDSet.add(id);
-	  } else {
-	    var key = getKeyFromID(id);
-	    rootByKey[key] = true;
-	  }
-	}
-
-	function removeRoot(id) {
-	  if (canUseCollections) {
-	    rootIDSet['delete'](id);
-	  } else {
-	    var key = getKeyFromID(id);
-	    delete rootByKey[key];
-	  }
-	}
-
-	function getRegisteredIDs() {
-	  if (canUseCollections) {
-	    return Array.from(itemMap.keys());
-	  } else {
-	    return Object.keys(itemByKey).map(getIDFromKey);
-	  }
-	}
-
-	function getRootIDs() {
-	  if (canUseCollections) {
-	    return Array.from(rootIDSet.keys());
-	  } else {
-	    return Object.keys(rootByKey).map(getIDFromKey);
-	  }
-	}
-
-	function purgeDeep(id) {
-	  var item = get(id);
-	  if (item) {
-	    var childIDs = item.childIDs;
-
-	    remove(id);
-	    childIDs.forEach(purgeDeep);
-	  }
-	}
-
-	function describeComponentFrame(name, source, ownerName) {
-	  return '\n    in ' + name + (source ? ' (at ' + source.fileName.replace(/^.*[\\\/]/, '') + ':' + source.lineNumber + ')' : ownerName ? ' (created by ' + ownerName + ')' : '');
-	}
-
-	function _getDisplayName(element) {
-	  if (element == null) {
-	    return '#empty';
-	  } else if (typeof element === 'string' || typeof element === 'number') {
-	    return '#text';
-	  } else if (typeof element.type === 'string') {
-	    return element.type;
-	  } else {
-	    return element.type.displayName || element.type.name || 'Unknown';
-	  }
-	}
-
-	function describeID(id) {
-	  var name = ReactComponentTreeHook.getDisplayName(id);
-	  var element = ReactComponentTreeHook.getElement(id);
-	  var ownerID = ReactComponentTreeHook.getOwnerID(id);
-	  var ownerName;
-	  if (ownerID) {
-	    ownerName = ReactComponentTreeHook.getDisplayName(ownerID);
-	  }
-	   false ? warning(element, 'ReactComponentTreeHook: Missing React element for debugID %s when ' + 'building stack', id) : void 0;
-	  return describeComponentFrame(name, element && element._source, ownerName);
-	}
-
-	var ReactComponentTreeHook = {
-	  onSetChildren: function onSetChildren(id, nextChildIDs) {
-	    var item = get(id);
-	    item.childIDs = nextChildIDs;
-
-	    for (var i = 0; i < nextChildIDs.length; i++) {
-	      var nextChildID = nextChildIDs[i];
-	      var nextChild = get(nextChildID);
-	      !nextChild ?  false ? invariant(false, 'Expected hook events to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('140') : void 0;
-	      !(nextChild.childIDs != null || _typeof(nextChild.element) !== 'object' || nextChild.element == null) ?  false ? invariant(false, 'Expected onSetChildren() to fire for a container child before its parent includes it in onSetChildren().') : _prodInvariant('141') : void 0;
-	      !nextChild.isMounted ?  false ? invariant(false, 'Expected onMountComponent() to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('71') : void 0;
-	      if (nextChild.parentID == null) {
-	        nextChild.parentID = id;
-	        // TODO: This shouldn't be necessary but mounting a new root during in
-	        // componentWillMount currently causes not-yet-mounted components to
-	        // be purged from our tree data so their parent ID is missing.
-	      }
-	      !(nextChild.parentID === id) ?  false ? invariant(false, 'Expected onBeforeMountComponent() parent and onSetChildren() to be consistent (%s has parents %s and %s).', nextChildID, nextChild.parentID, id) : _prodInvariant('142', nextChildID, nextChild.parentID, id) : void 0;
-	    }
-	  },
-	  onBeforeMountComponent: function onBeforeMountComponent(id, element, parentID) {
-	    create(id, element, parentID);
-	  },
-	  onBeforeUpdateComponent: function onBeforeUpdateComponent(id, element) {
-	    var item = get(id);
-	    if (!item || !item.isMounted) {
-	      // We may end up here as a result of setState() in componentWillUnmount().
-	      // In this case, ignore the element.
-	      return;
-	    }
-	    item.element = element;
-	  },
-	  onMountComponent: function onMountComponent(id) {
-	    var item = get(id);
-	    item.isMounted = true;
-	    var isRoot = item.parentID === 0;
-	    if (isRoot) {
-	      addRoot(id);
-	    }
-	  },
-	  onUpdateComponent: function onUpdateComponent(id) {
-	    var item = get(id);
-	    if (!item || !item.isMounted) {
-	      // We may end up here as a result of setState() in componentWillUnmount().
-	      // In this case, ignore the element.
-	      return;
-	    }
-	    item.updateCount++;
-	  },
-	  onUnmountComponent: function onUnmountComponent(id) {
-	    var item = get(id);
-	    if (item) {
-	      // We need to check if it exists.
-	      // `item` might not exist if it is inside an error boundary, and a sibling
-	      // error boundary child threw while mounting. Then this instance never
-	      // got a chance to mount, but it still gets an unmounting event during
-	      // the error boundary cleanup.
-	      item.isMounted = false;
-	      var isRoot = item.parentID === 0;
-	      if (isRoot) {
-	        removeRoot(id);
-	      }
-	    }
-	    unmountedIDs.push(id);
-	  },
-	  purgeUnmountedComponents: function purgeUnmountedComponents() {
-	    if (ReactComponentTreeHook._preventPurging) {
-	      // Should only be used for testing.
-	      return;
-	    }
-
-	    for (var i = 0; i < unmountedIDs.length; i++) {
-	      var id = unmountedIDs[i];
-	      purgeDeep(id);
-	    }
-	    unmountedIDs.length = 0;
-	  },
-	  isMounted: function isMounted(id) {
-	    var item = get(id);
-	    return item ? item.isMounted : false;
-	  },
-	  getCurrentStackAddendum: function getCurrentStackAddendum(topElement) {
-	    var info = '';
-	    if (topElement) {
-	      var type = topElement.type;
-	      var name = typeof type === 'function' ? type.displayName || type.name : type;
-	      var owner = topElement._owner;
-	      info += describeComponentFrame(name || 'Unknown', topElement._source, owner && owner.getName());
-	    }
-
-	    var currentOwner = ReactCurrentOwner.current;
-	    var id = currentOwner && currentOwner._debugID;
-
-	    info += ReactComponentTreeHook.getStackAddendumByID(id);
-	    return info;
-	  },
-	  getStackAddendumByID: function getStackAddendumByID(id) {
-	    var info = '';
-	    while (id) {
-	      info += describeID(id);
-	      id = ReactComponentTreeHook.getParentID(id);
-	    }
-	    return info;
-	  },
-	  getChildIDs: function getChildIDs(id) {
-	    var item = get(id);
-	    return item ? item.childIDs : [];
-	  },
-	  getDisplayName: function getDisplayName(id) {
-	    var element = ReactComponentTreeHook.getElement(id);
-	    if (!element) {
-	      return null;
-	    }
-	    return _getDisplayName(element);
-	  },
-	  getElement: function getElement(id) {
-	    var item = get(id);
-	    return item ? item.element : null;
-	  },
-	  getOwnerID: function getOwnerID(id) {
-	    var element = ReactComponentTreeHook.getElement(id);
-	    if (!element || !element._owner) {
-	      return null;
-	    }
-	    return element._owner._debugID;
-	  },
-	  getParentID: function getParentID(id) {
-	    var item = get(id);
-	    return item ? item.parentID : null;
-	  },
-	  getSource: function getSource(id) {
-	    var item = get(id);
-	    var element = item ? item.element : null;
-	    var source = element != null ? element._source : null;
-	    return source;
-	  },
-	  getText: function getText(id) {
-	    var element = ReactComponentTreeHook.getElement(id);
-	    if (typeof element === 'string') {
-	      return element;
-	    } else if (typeof element === 'number') {
-	      return '' + element;
-	    } else {
-	      return null;
-	    }
-	  },
-	  getUpdateCount: function getUpdateCount(id) {
-	    var item = get(id);
-	    return item ? item.updateCount : 0;
-	  },
-
-	  getRegisteredIDs: getRegisteredIDs,
-
-	  getRootIDs: getRootIDs
-	};
-
-	module.exports = ReactComponentTreeHook;
-
-/***/ },
-/* 154 */
+/* 150 */
 /***/ function(module, exports) {
 
 	/**
@@ -21893,7 +21383,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = shallowEqual;
 
 /***/ },
-/* 155 */
+/* 151 */
 /***/ function(module, exports) {
 
 	/**
@@ -21904,7 +21394,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule shouldUpdateReactComponent
 	 */
 
 	'use strict';
@@ -21942,7 +21431,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = shouldUpdateReactComponent;
 
 /***/ },
-/* 156 */
+/* 152 */
 /***/ function(module, exports) {
 
 	/**
@@ -21953,7 +21442,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactEmptyComponent
 	 */
 
 	'use strict';
@@ -21977,7 +21465,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactEmptyComponent;
 
 /***/ },
-/* 157 */
+/* 153 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -21988,12 +21476,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactHostComponent
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
 	var invariant = __webpack_require__(8);
@@ -22058,7 +21545,685 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactHostComponent;
 
 /***/ },
+/* 154 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	var nextDebugID = 1;
+
+	function getNextDebugID() {
+	  return nextDebugID++;
+	}
+
+	module.exports = getNextDebugID;
+
+/***/ },
+/* 155 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	/**
+	 * Escape and wrap key so it is safe to use as a reactid
+	 *
+	 * @param {string} key to be escaped.
+	 * @return {string} the escaped key.
+	 */
+
+	function escape(key) {
+	  var escapeRegex = /[=:]/g;
+	  var escaperLookup = {
+	    '=': '=0',
+	    ':': '=2'
+	  };
+	  var escapedString = ('' + key).replace(escapeRegex, function (match) {
+	    return escaperLookup[match];
+	  });
+
+	  return '$' + escapedString;
+	}
+
+	/**
+	 * Unescape and unwrap key for human-readable display
+	 *
+	 * @param {string} key to unescape.
+	 * @return {string} the unescaped key.
+	 */
+	function unescape(key) {
+	  var unescapeRegex = /(=0|=2)/g;
+	  var unescaperLookup = {
+	    '=0': '=',
+	    '=2': ':'
+	  };
+	  var keySubstring = key[0] === '.' && key[1] === '$' ? key.substring(2) : key.substring(1);
+
+	  return ('' + keySubstring).replace(unescapeRegex, function (match) {
+	    return unescaperLookup[match];
+	  });
+	}
+
+	var KeyEscapeUtils = {
+	  escape: escape,
+	  unescape: unescape
+	};
+
+	module.exports = KeyEscapeUtils;
+
+/***/ },
+/* 156 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 */
+
+	'use strict';
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	var _prodInvariant = __webpack_require__(68);
+
+	var ReactCurrentOwner = __webpack_require__(10);
+	var REACT_ELEMENT_TYPE = __webpack_require__(157);
+
+	var getIteratorFn = __webpack_require__(158);
+	var invariant = __webpack_require__(8);
+	var KeyEscapeUtils = __webpack_require__(155);
+	var warning = __webpack_require__(11);
+
+	var SEPARATOR = '.';
+	var SUBSEPARATOR = ':';
+
+	/**
+	 * This is inlined from ReactElement since this file is shared between
+	 * isomorphic and renderers. We could extract this to a
+	 *
+	 */
+
+	/**
+	 * TODO: Test that a single child and an array with one item have the same key
+	 * pattern.
+	 */
+
+	var didWarnAboutMaps = false;
+
+	/**
+	 * Generate a key string that identifies a component within a set.
+	 *
+	 * @param {*} component A component that could contain a manual key.
+	 * @param {number} index Index that is used if a manual key is not provided.
+	 * @return {string}
+	 */
+	function getComponentKey(component, index) {
+	  // Do some typechecking here since we call this blindly. We want to ensure
+	  // that we don't block potential future ES APIs.
+	  if (component && (typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && component.key != null) {
+	    // Explicit key
+	    return KeyEscapeUtils.escape(component.key);
+	  }
+	  // Implicit key determined by the index in the set
+	  return index.toString(36);
+	}
+
+	/**
+	 * @param {?*} children Children tree container.
+	 * @param {!string} nameSoFar Name of the key path so far.
+	 * @param {!function} callback Callback to invoke with each child found.
+	 * @param {?*} traverseContext Used to pass information throughout the traversal
+	 * process.
+	 * @return {!number} The number of children in this subtree.
+	 */
+	function traverseAllChildrenImpl(children, nameSoFar, callback, traverseContext) {
+	  var type = typeof children === 'undefined' ? 'undefined' : _typeof(children);
+
+	  if (type === 'undefined' || type === 'boolean') {
+	    // All of the above are perceived as null.
+	    children = null;
+	  }
+
+	  if (children === null || type === 'string' || type === 'number' ||
+	  // The following is inlined from ReactElement. This means we can optimize
+	  // some checks. React Fiber also inlines this logic for similar purposes.
+	  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+	    callback(traverseContext, children,
+	    // If it's the only child, treat the name as if it was wrapped in an array
+	    // so that it's consistent if the number of children grows.
+	    nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar);
+	    return 1;
+	  }
+
+	  var child;
+	  var nextName;
+	  var subtreeCount = 0; // Count of children found in the current subtree.
+	  var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+	  if (Array.isArray(children)) {
+	    for (var i = 0; i < children.length; i++) {
+	      child = children[i];
+	      nextName = nextNamePrefix + getComponentKey(child, i);
+	      subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+	    }
+	  } else {
+	    var iteratorFn = getIteratorFn(children);
+	    if (iteratorFn) {
+	      var iterator = iteratorFn.call(children);
+	      var step;
+	      if (iteratorFn !== children.entries) {
+	        var ii = 0;
+	        while (!(step = iterator.next()).done) {
+	          child = step.value;
+	          nextName = nextNamePrefix + getComponentKey(child, ii++);
+	          subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+	        }
+	      } else {
+	        if (false) {
+	          var mapsAsChildrenAddendum = '';
+	          if (ReactCurrentOwner.current) {
+	            var mapsAsChildrenOwnerName = ReactCurrentOwner.current.getName();
+	            if (mapsAsChildrenOwnerName) {
+	              mapsAsChildrenAddendum = ' Check the render method of `' + mapsAsChildrenOwnerName + '`.';
+	            }
+	          }
+	          process.env.NODE_ENV !== 'production' ? warning(didWarnAboutMaps, 'Using Maps as children is not yet fully supported. It is an ' + 'experimental feature that might be removed. Convert it to a ' + 'sequence / iterable of keyed ReactElements instead.%s', mapsAsChildrenAddendum) : void 0;
+	          didWarnAboutMaps = true;
+	        }
+	        // Iterator will provide entry [k,v] tuples rather than values.
+	        while (!(step = iterator.next()).done) {
+	          var entry = step.value;
+	          if (entry) {
+	            child = entry[1];
+	            nextName = nextNamePrefix + KeyEscapeUtils.escape(entry[0]) + SUBSEPARATOR + getComponentKey(child, 0);
+	            subtreeCount += traverseAllChildrenImpl(child, nextName, callback, traverseContext);
+	          }
+	        }
+	      }
+	    } else if (type === 'object') {
+	      var addendum = '';
+	      if (false) {
+	        addendum = ' If you meant to render a collection of children, use an array ' + 'instead or wrap the object using createFragment(object) from the ' + 'React add-ons.';
+	        if (children._isReactElement) {
+	          addendum = ' It looks like you\'re using an element created by a different ' + 'version of React. Make sure to use only one copy of React.';
+	        }
+	        if (ReactCurrentOwner.current) {
+	          var name = ReactCurrentOwner.current.getName();
+	          if (name) {
+	            addendum += ' Check the render method of `' + name + '`.';
+	          }
+	        }
+	      }
+	      var childrenString = String(children);
+	       true ?  false ? invariant(false, 'Objects are not valid as a React child (found: %s).%s', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : _prodInvariant('31', childrenString === '[object Object]' ? 'object with keys {' + Object.keys(children).join(', ') + '}' : childrenString, addendum) : void 0;
+	    }
+	  }
+
+	  return subtreeCount;
+	}
+
+	/**
+	 * Traverses children that are typically specified as `props.children`, but
+	 * might also be specified through attributes:
+	 *
+	 * - `traverseAllChildren(this.props.children, ...)`
+	 * - `traverseAllChildren(this.props.leftPanelChildren, ...)`
+	 *
+	 * The `traverseContext` is an optional argument that is passed through the
+	 * entire traversal. It can be used to store accumulations or anything else that
+	 * the callback might find relevant.
+	 *
+	 * @param {?*} children Children tree object.
+	 * @param {!function} callback To invoke upon traversing each child.
+	 * @param {?*} traverseContext Context for traversal.
+	 * @return {!number} The number of children in this subtree.
+	 */
+	function traverseAllChildren(children, callback, traverseContext) {
+	  if (children == null) {
+	    return 0;
+	  }
+
+	  return traverseAllChildrenImpl(children, '', callback, traverseContext);
+	}
+
+	module.exports = traverseAllChildren;
+
+/***/ },
+/* 157 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2014-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	// The Symbol used to tag the ReactElement type. If there is no native Symbol
+	// nor polyfill, then a plain number is used for performance.
+
+	var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+	module.exports = REACT_ELEMENT_TYPE;
+
+/***/ },
 /* 158 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	/* global Symbol */
+
+	var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+	var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+	/**
+	 * Returns the iterator method function contained on the iterable object.
+	 *
+	 * Be sure to invoke the function with the iterable as context:
+	 *
+	 *     var iteratorFn = getIteratorFn(myIterable);
+	 *     if (iteratorFn) {
+	 *       var iterator = iteratorFn.call(myIterable);
+	 *       ...
+	 *     }
+	 *
+	 * @param {?object} maybeIterable
+	 * @return {?function}
+	 */
+	function getIteratorFn(maybeIterable) {
+	  var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+	  if (typeof iteratorFn === 'function') {
+	    return iteratorFn;
+	  }
+	}
+
+	module.exports = getIteratorFn;
+
+/***/ },
+/* 159 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/**
+	 * Copyright 2016-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 * 
+	 */
+
+	'use strict';
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+	var _prodInvariant = __webpack_require__(7);
+
+	var ReactCurrentOwner = __webpack_require__(10);
+
+	var invariant = __webpack_require__(8);
+	var warning = __webpack_require__(11);
+
+	function isNative(fn) {
+	  // Based on isNative() from Lodash
+	  var funcToString = Function.prototype.toString;
+	  var hasOwnProperty = Object.prototype.hasOwnProperty;
+	  var reIsNative = RegExp('^' + funcToString
+	  // Take an example native function source for comparison
+	  .call(hasOwnProperty)
+	  // Strip regex characters so we can use it for regex
+	  .replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+	  // Remove hasOwnProperty from the template to make it generic
+	  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
+	  try {
+	    var source = funcToString.call(fn);
+	    return reIsNative.test(source);
+	  } catch (err) {
+	    return false;
+	  }
+	}
+
+	var canUseCollections =
+	// Array.from
+	typeof Array.from === 'function' &&
+	// Map
+	typeof Map === 'function' && isNative(Map) &&
+	// Map.prototype.keys
+	Map.prototype != null && typeof Map.prototype.keys === 'function' && isNative(Map.prototype.keys) &&
+	// Set
+	typeof Set === 'function' && isNative(Set) &&
+	// Set.prototype.keys
+	Set.prototype != null && typeof Set.prototype.keys === 'function' && isNative(Set.prototype.keys);
+
+	var setItem;
+	var getItem;
+	var removeItem;
+	var getItemIDs;
+	var addRoot;
+	var removeRoot;
+	var getRootIDs;
+
+	if (canUseCollections) {
+	  var itemMap = new Map();
+	  var rootIDSet = new Set();
+
+	  setItem = function setItem(id, item) {
+	    itemMap.set(id, item);
+	  };
+	  getItem = function getItem(id) {
+	    return itemMap.get(id);
+	  };
+	  removeItem = function removeItem(id) {
+	    itemMap['delete'](id);
+	  };
+	  getItemIDs = function getItemIDs() {
+	    return Array.from(itemMap.keys());
+	  };
+
+	  addRoot = function addRoot(id) {
+	    rootIDSet.add(id);
+	  };
+	  removeRoot = function removeRoot(id) {
+	    rootIDSet['delete'](id);
+	  };
+	  getRootIDs = function getRootIDs() {
+	    return Array.from(rootIDSet.keys());
+	  };
+	} else {
+	  var itemByKey = {};
+	  var rootByKey = {};
+
+	  // Use non-numeric keys to prevent V8 performance issues:
+	  // https://github.com/facebook/react/pull/7232
+	  var getKeyFromID = function getKeyFromID(id) {
+	    return '.' + id;
+	  };
+	  var getIDFromKey = function getIDFromKey(key) {
+	    return parseInt(key.substr(1), 10);
+	  };
+
+	  setItem = function setItem(id, item) {
+	    var key = getKeyFromID(id);
+	    itemByKey[key] = item;
+	  };
+	  getItem = function getItem(id) {
+	    var key = getKeyFromID(id);
+	    return itemByKey[key];
+	  };
+	  removeItem = function removeItem(id) {
+	    var key = getKeyFromID(id);
+	    delete itemByKey[key];
+	  };
+	  getItemIDs = function getItemIDs() {
+	    return Object.keys(itemByKey).map(getIDFromKey);
+	  };
+
+	  addRoot = function addRoot(id) {
+	    var key = getKeyFromID(id);
+	    rootByKey[key] = true;
+	  };
+	  removeRoot = function removeRoot(id) {
+	    var key = getKeyFromID(id);
+	    delete rootByKey[key];
+	  };
+	  getRootIDs = function getRootIDs() {
+	    return Object.keys(rootByKey).map(getIDFromKey);
+	  };
+	}
+
+	var unmountedIDs = [];
+
+	function purgeDeep(id) {
+	  var item = getItem(id);
+	  if (item) {
+	    var childIDs = item.childIDs;
+
+	    removeItem(id);
+	    childIDs.forEach(purgeDeep);
+	  }
+	}
+
+	function describeComponentFrame(name, source, ownerName) {
+	  return '\n    in ' + (name || 'Unknown') + (source ? ' (at ' + source.fileName.replace(/^.*[\\\/]/, '') + ':' + source.lineNumber + ')' : ownerName ? ' (created by ' + ownerName + ')' : '');
+	}
+
+	function _getDisplayName(element) {
+	  if (element == null) {
+	    return '#empty';
+	  } else if (typeof element === 'string' || typeof element === 'number') {
+	    return '#text';
+	  } else if (typeof element.type === 'string') {
+	    return element.type;
+	  } else {
+	    return element.type.displayName || element.type.name || 'Unknown';
+	  }
+	}
+
+	function describeID(id) {
+	  var name = ReactComponentTreeHook.getDisplayName(id);
+	  var element = ReactComponentTreeHook.getElement(id);
+	  var ownerID = ReactComponentTreeHook.getOwnerID(id);
+	  var ownerName;
+	  if (ownerID) {
+	    ownerName = ReactComponentTreeHook.getDisplayName(ownerID);
+	  }
+	   false ? warning(element, 'ReactComponentTreeHook: Missing React element for debugID %s when ' + 'building stack', id) : void 0;
+	  return describeComponentFrame(name, element && element._source, ownerName);
+	}
+
+	var ReactComponentTreeHook = {
+	  onSetChildren: function onSetChildren(id, nextChildIDs) {
+	    var item = getItem(id);
+	    !item ?  false ? invariant(false, 'Item must have been set') : _prodInvariant('144') : void 0;
+	    item.childIDs = nextChildIDs;
+
+	    for (var i = 0; i < nextChildIDs.length; i++) {
+	      var nextChildID = nextChildIDs[i];
+	      var nextChild = getItem(nextChildID);
+	      !nextChild ?  false ? invariant(false, 'Expected hook events to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('140') : void 0;
+	      !(nextChild.childIDs != null || _typeof(nextChild.element) !== 'object' || nextChild.element == null) ?  false ? invariant(false, 'Expected onSetChildren() to fire for a container child before its parent includes it in onSetChildren().') : _prodInvariant('141') : void 0;
+	      !nextChild.isMounted ?  false ? invariant(false, 'Expected onMountComponent() to fire for the child before its parent includes it in onSetChildren().') : _prodInvariant('71') : void 0;
+	      if (nextChild.parentID == null) {
+	        nextChild.parentID = id;
+	        // TODO: This shouldn't be necessary but mounting a new root during in
+	        // componentWillMount currently causes not-yet-mounted components to
+	        // be purged from our tree data so their parent id is missing.
+	      }
+	      !(nextChild.parentID === id) ?  false ? invariant(false, 'Expected onBeforeMountComponent() parent and onSetChildren() to be consistent (%s has parents %s and %s).', nextChildID, nextChild.parentID, id) : _prodInvariant('142', nextChildID, nextChild.parentID, id) : void 0;
+	    }
+	  },
+	  onBeforeMountComponent: function onBeforeMountComponent(id, element, parentID) {
+	    var item = {
+	      element: element,
+	      parentID: parentID,
+	      text: null,
+	      childIDs: [],
+	      isMounted: false,
+	      updateCount: 0
+	    };
+	    setItem(id, item);
+	  },
+	  onBeforeUpdateComponent: function onBeforeUpdateComponent(id, element) {
+	    var item = getItem(id);
+	    if (!item || !item.isMounted) {
+	      // We may end up here as a result of setState() in componentWillUnmount().
+	      // In this case, ignore the element.
+	      return;
+	    }
+	    item.element = element;
+	  },
+	  onMountComponent: function onMountComponent(id) {
+	    var item = getItem(id);
+	    !item ?  false ? invariant(false, 'Item must have been set') : _prodInvariant('144') : void 0;
+	    item.isMounted = true;
+	    var isRoot = item.parentID === 0;
+	    if (isRoot) {
+	      addRoot(id);
+	    }
+	  },
+	  onUpdateComponent: function onUpdateComponent(id) {
+	    var item = getItem(id);
+	    if (!item || !item.isMounted) {
+	      // We may end up here as a result of setState() in componentWillUnmount().
+	      // In this case, ignore the element.
+	      return;
+	    }
+	    item.updateCount++;
+	  },
+	  onUnmountComponent: function onUnmountComponent(id) {
+	    var item = getItem(id);
+	    if (item) {
+	      // We need to check if it exists.
+	      // `item` might not exist if it is inside an error boundary, and a sibling
+	      // error boundary child threw while mounting. Then this instance never
+	      // got a chance to mount, but it still gets an unmounting event during
+	      // the error boundary cleanup.
+	      item.isMounted = false;
+	      var isRoot = item.parentID === 0;
+	      if (isRoot) {
+	        removeRoot(id);
+	      }
+	    }
+	    unmountedIDs.push(id);
+	  },
+	  purgeUnmountedComponents: function purgeUnmountedComponents() {
+	    if (ReactComponentTreeHook._preventPurging) {
+	      // Should only be used for testing.
+	      return;
+	    }
+
+	    for (var i = 0; i < unmountedIDs.length; i++) {
+	      var id = unmountedIDs[i];
+	      purgeDeep(id);
+	    }
+	    unmountedIDs.length = 0;
+	  },
+	  isMounted: function isMounted(id) {
+	    var item = getItem(id);
+	    return item ? item.isMounted : false;
+	  },
+	  getCurrentStackAddendum: function getCurrentStackAddendum(topElement) {
+	    var info = '';
+	    if (topElement) {
+	      var name = _getDisplayName(topElement);
+	      var owner = topElement._owner;
+	      info += describeComponentFrame(name, topElement._source, owner && owner.getName());
+	    }
+
+	    var currentOwner = ReactCurrentOwner.current;
+	    var id = currentOwner && currentOwner._debugID;
+
+	    info += ReactComponentTreeHook.getStackAddendumByID(id);
+	    return info;
+	  },
+	  getStackAddendumByID: function getStackAddendumByID(id) {
+	    var info = '';
+	    while (id) {
+	      info += describeID(id);
+	      id = ReactComponentTreeHook.getParentID(id);
+	    }
+	    return info;
+	  },
+	  getChildIDs: function getChildIDs(id) {
+	    var item = getItem(id);
+	    return item ? item.childIDs : [];
+	  },
+	  getDisplayName: function getDisplayName(id) {
+	    var element = ReactComponentTreeHook.getElement(id);
+	    if (!element) {
+	      return null;
+	    }
+	    return _getDisplayName(element);
+	  },
+	  getElement: function getElement(id) {
+	    var item = getItem(id);
+	    return item ? item.element : null;
+	  },
+	  getOwnerID: function getOwnerID(id) {
+	    var element = ReactComponentTreeHook.getElement(id);
+	    if (!element || !element._owner) {
+	      return null;
+	    }
+	    return element._owner._debugID;
+	  },
+	  getParentID: function getParentID(id) {
+	    var item = getItem(id);
+	    return item ? item.parentID : null;
+	  },
+	  getSource: function getSource(id) {
+	    var item = getItem(id);
+	    var element = item ? item.element : null;
+	    var source = element != null ? element._source : null;
+	    return source;
+	  },
+	  getText: function getText(id) {
+	    var element = ReactComponentTreeHook.getElement(id);
+	    if (typeof element === 'string') {
+	      return element;
+	    } else if (typeof element === 'number') {
+	      return '' + element;
+	    } else {
+	      return null;
+	    }
+	  },
+	  getUpdateCount: function getUpdateCount(id) {
+	    var item = getItem(id);
+	    return item ? item.updateCount : 0;
+	  },
+
+	  getRootIDs: getRootIDs,
+	  getRegisteredIDs: getItemIDs
+	};
+
+	module.exports = ReactComponentTreeHook;
+
+/***/ },
+/* 160 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
@@ -22069,7 +22234,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule flattenChildren
 	 * 
 	 */
 
@@ -22077,8 +22241,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var KeyEscapeUtils = __webpack_require__(16);
-	var traverseAllChildren = __webpack_require__(14);
+	var KeyEscapeUtils = __webpack_require__(155);
+	var traverseAllChildren = __webpack_require__(156);
 	var warning = __webpack_require__(11);
 
 	var ReactComponentTreeHook;
@@ -22089,7 +22253,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // https://github.com/facebook/react/issues/7240
 	  // Remove the inline requires when we don't need them anymore:
 	  // https://github.com/facebook/react/pull/7178
-	  ReactComponentTreeHook = __webpack_require__(153);
+	  ReactComponentTreeHook = __webpack_require__(159);
 	}
 
 	/**
@@ -22105,7 +22269,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var keyUnique = result[name] === undefined;
 	    if (false) {
 	      if (!ReactComponentTreeHook) {
-	        ReactComponentTreeHook = require('./ReactComponentTreeHook');
+	        ReactComponentTreeHook = require('react/lib/ReactComponentTreeHook');
 	      }
 	      if (!keyUnique) {
 	        process.env.NODE_ENV !== 'production' ? warning(false, 'flattenChildren(...): Encountered two children with the same key, ' + '`%s`. Child keys must be unique; when two children share a key, only ' + 'the first child will be used.%s', KeyEscapeUtils.unescape(name), ReactComponentTreeHook.getStackAddendumByID(selfDebugID)) : void 0;
@@ -22139,10 +22303,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 	module.exports = flattenChildren;
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(148)))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(146)))
 
 /***/ },
-/* 159 */
+/* 161 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -22153,17 +22317,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactServerRenderingTransaction
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var PooledClass = __webpack_require__(6);
+	var PooledClass = __webpack_require__(83);
 	var Transaction = __webpack_require__(96);
 	var ReactInstrumentation = __webpack_require__(95);
-	var ReactServerUpdateQueue = __webpack_require__(160);
+	var ReactServerUpdateQueue = __webpack_require__(162);
 
 	/**
 	 * Executed within the scope of the `Transaction` instance. Consider these as
@@ -22230,14 +22393,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  rollback: function rollback() {}
 	};
 
-	_assign(ReactServerRenderingTransaction.prototype, Transaction.Mixin, Mixin);
+	_assign(ReactServerRenderingTransaction.prototype, Transaction, Mixin);
 
 	PooledClass.addPoolingTo(ReactServerRenderingTransaction);
 
 	module.exports = ReactServerRenderingTransaction;
 
 /***/ },
-/* 160 */
+/* 162 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -22248,7 +22411,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactServerUpdateQueue
 	 * 
 	 */
 
@@ -22260,8 +22422,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
-	var ReactUpdateQueue = __webpack_require__(161);
-	var Transaction = __webpack_require__(96);
+	var ReactUpdateQueue = __webpack_require__(163);
+
 	var warning = __webpack_require__(11);
 
 	function warnNoop(publicInstance, callerName) {
@@ -22280,8 +22442,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 
 	var ReactServerUpdateQueue = function () {
-	  /* :: transaction: Transaction; */
-
 	  function ReactServerUpdateQueue(transaction) {
 	    _classCallCheck(this, ReactServerUpdateQueue);
 
@@ -22382,7 +22542,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactServerUpdateQueue;
 
 /***/ },
-/* 161 */
+/* 163 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -22393,17 +22553,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactUpdateQueue
 	 */
 
 	'use strict';
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactInstanceMap = __webpack_require__(146);
+	var ReactInstanceMap = __webpack_require__(144);
 	var ReactInstrumentation = __webpack_require__(95);
 	var ReactUpdates = __webpack_require__(89);
 
@@ -22615,7 +22774,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactUpdateQueue;
 
 /***/ },
-/* 162 */
+/* 164 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -22626,7 +22785,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule validateDOMNesting
 	 */
 
 	'use strict';
@@ -23002,7 +23160,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = validateDOMNesting;
 
 /***/ },
-/* 163 */
+/* 165 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23013,7 +23171,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMEmptyComponent
 	 */
 
 	'use strict';
@@ -23021,7 +23178,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _assign = __webpack_require__(4);
 
 	var DOMLazyTree = __webpack_require__(109);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 
 	var ReactDOMEmptyComponent = function ReactDOMEmptyComponent(instantiate) {
 	  // ReactCompositeComponent uses this:
@@ -23067,7 +23224,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMEmptyComponent;
 
 /***/ },
-/* 164 */
+/* 166 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23078,12 +23235,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMTreeTraversal
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var invariant = __webpack_require__(8);
 
@@ -23164,10 +23320,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	  var i;
 	  for (i = path.length; i-- > 0;) {
-	    fn(path[i], false, arg);
+	    fn(path[i], 'captured', arg);
 	  }
 	  for (i = 0; i < path.length; i++) {
-	    fn(path[i], true, arg);
+	    fn(path[i], 'bubbled', arg);
 	  }
 	}
 
@@ -23192,10 +23348,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	  var i;
 	  for (i = 0; i < pathFrom.length; i++) {
-	    fn(pathFrom[i], true, argFrom);
+	    fn(pathFrom[i], 'bubbled', argFrom);
 	  }
 	  for (i = pathTo.length; i-- > 0;) {
-	    fn(pathTo[i], false, argTo);
+	    fn(pathTo[i], 'captured', argTo);
 	  }
 	}
 
@@ -23208,7 +23364,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ },
-/* 165 */
+/* 167 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23219,21 +23375,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMTextComponent
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7),
+	var _prodInvariant = __webpack_require__(68),
 	    _assign = __webpack_require__(4);
 
 	var DOMChildrenOperations = __webpack_require__(108);
 	var DOMLazyTree = __webpack_require__(109);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var ReactDOMComponentTree = __webpack_require__(67);
 
 	var escapeTextContentForBrowser = __webpack_require__(114);
 	var invariant = __webpack_require__(8);
-	var validateDOMNesting = __webpack_require__(162);
+	var validateDOMNesting = __webpack_require__(164);
 
 	/**
 	 * Text nodes violate a couple assumptions that React makes about components:
@@ -23377,7 +23532,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMTextComponent;
 
 /***/ },
-/* 166 */
+/* 168 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23388,7 +23543,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDefaultBatchingStrategy
 	 */
 
 	'use strict';
@@ -23418,7 +23572,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this.reinitializeTransaction();
 	}
 
-	_assign(ReactDefaultBatchingStrategyTransaction.prototype, Transaction.Mixin, {
+	_assign(ReactDefaultBatchingStrategyTransaction.prototype, Transaction, {
 	  getTransactionWrappers: function getTransactionWrappers() {
 	    return TRANSACTION_WRAPPERS;
 	  }
@@ -23440,9 +23594,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    // The code is written this way to avoid extra allocations
 	    if (alreadyBatchingUpdates) {
-	      callback(a, b, c, d, e);
+	      return callback(a, b, c, d, e);
 	    } else {
-	      transaction.perform(callback, null, a, b, c, d, e);
+	      return transaction.perform(callback, null, a, b, c, d, e);
 	    }
 	  }
 	};
@@ -23450,7 +23604,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDefaultBatchingStrategy;
 
 /***/ },
-/* 167 */
+/* 169 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23461,21 +23615,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactEventListener
 	 */
 
 	'use strict';
 
 	var _assign = __webpack_require__(4);
 
-	var EventListener = __webpack_require__(168);
-	var ExecutionEnvironment = __webpack_require__(82);
-	var PooledClass = __webpack_require__(6);
-	var ReactDOMComponentTree = __webpack_require__(69);
+	var EventListener = __webpack_require__(170);
+	var ExecutionEnvironment = __webpack_require__(81);
+	var PooledClass = __webpack_require__(83);
+	var ReactDOMComponentTree = __webpack_require__(67);
 	var ReactUpdates = __webpack_require__(89);
 
 	var getEventTarget = __webpack_require__(97);
-	var getUnboundedScrollPosition = __webpack_require__(169);
+	var getUnboundedScrollPosition = __webpack_require__(171);
 
 	/**
 	 * Find the deepest React component completely containing the root of the
@@ -23557,13 +23710,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @param {string} topLevelType Record from `EventConstants`.
 	   * @param {string} handlerBaseName Event name (e.g. "click").
-	   * @param {object} handle Element on which to attach listener.
+	   * @param {object} element Element on which to attach listener.
 	   * @return {?object} An object with a remove function which will forcefully
 	   *                  remove the listener.
 	   * @internal
 	   */
-	  trapBubbledEvent: function trapBubbledEvent(topLevelType, handlerBaseName, handle) {
-	    var element = handle;
+	  trapBubbledEvent: function trapBubbledEvent(topLevelType, handlerBaseName, element) {
 	    if (!element) {
 	      return null;
 	    }
@@ -23575,13 +23727,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	   *
 	   * @param {string} topLevelType Record from `EventConstants`.
 	   * @param {string} handlerBaseName Event name (e.g. "click").
-	   * @param {object} handle Element on which to attach listener.
+	   * @param {object} element Element on which to attach listener.
 	   * @return {?object} An object with a remove function which will forcefully
 	   *                  remove the listener.
 	   * @internal
 	   */
-	  trapCapturedEvent: function trapCapturedEvent(topLevelType, handlerBaseName, handle) {
-	    var element = handle;
+	  trapCapturedEvent: function trapCapturedEvent(topLevelType, handlerBaseName, element) {
 	    if (!element) {
 	      return null;
 	    }
@@ -23612,7 +23763,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactEventListener;
 
 /***/ },
-/* 168 */
+/* 170 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -23700,7 +23851,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = EventListener;
 
 /***/ },
-/* 169 */
+/* 171 */
 /***/ function(module, exports) {
 
 	/**
@@ -23743,7 +23894,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getUnboundedScrollPosition;
 
 /***/ },
-/* 170 */
+/* 172 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23754,24 +23905,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactInjection
 	 */
 
 	'use strict';
 
-	var DOMProperty = __webpack_require__(70);
-	var EventPluginHub = __webpack_require__(76);
-	var EventPluginUtils = __webpack_require__(78);
-	var ReactComponentEnvironment = __webpack_require__(145);
-	var ReactClass = __webpack_require__(21);
-	var ReactEmptyComponent = __webpack_require__(156);
-	var ReactBrowserEventEmitter = __webpack_require__(134);
-	var ReactHostComponent = __webpack_require__(157);
+	var DOMProperty = __webpack_require__(69);
+	var EventPluginHub = __webpack_require__(75);
+	var EventPluginUtils = __webpack_require__(77);
+	var ReactComponentEnvironment = __webpack_require__(143);
+	var ReactEmptyComponent = __webpack_require__(152);
+	var ReactBrowserEventEmitter = __webpack_require__(133);
+	var ReactHostComponent = __webpack_require__(153);
 	var ReactUpdates = __webpack_require__(89);
 
 	var ReactInjection = {
 	  Component: ReactComponentEnvironment.injection,
-	  Class: ReactClass.injection,
 	  DOMProperty: DOMProperty.injection,
 	  EmptyComponent: ReactEmptyComponent.injection,
 	  EventPluginHub: EventPluginHub.injection,
@@ -23784,7 +23932,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactInjection;
 
 /***/ },
-/* 171 */
+/* 173 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23795,7 +23943,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactReconcileTransaction
 	 */
 
 	'use strict';
@@ -23803,12 +23950,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _assign = __webpack_require__(4);
 
 	var CallbackQueue = __webpack_require__(90);
-	var PooledClass = __webpack_require__(6);
-	var ReactBrowserEventEmitter = __webpack_require__(134);
-	var ReactInputSelection = __webpack_require__(172);
+	var PooledClass = __webpack_require__(83);
+	var ReactBrowserEventEmitter = __webpack_require__(133);
+	var ReactInputSelection = __webpack_require__(174);
 	var ReactInstrumentation = __webpack_require__(95);
 	var Transaction = __webpack_require__(96);
-	var ReactUpdateQueue = __webpack_require__(161);
+	var ReactUpdateQueue = __webpack_require__(163);
 
 	/**
 	 * Ensures that, when possible, the selection range (currently selected text
@@ -23960,14 +24107,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	_assign(ReactReconcileTransaction.prototype, Transaction.Mixin, Mixin);
+	_assign(ReactReconcileTransaction.prototype, Transaction, Mixin);
 
 	PooledClass.addPoolingTo(ReactReconcileTransaction);
 
 	module.exports = ReactReconcileTransaction;
 
 /***/ },
-/* 172 */
+/* 174 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -23978,16 +24125,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactInputSelection
 	 */
 
 	'use strict';
 
-	var ReactDOMSelection = __webpack_require__(173);
+	var ReactDOMSelection = __webpack_require__(175);
 
-	var containsNode = __webpack_require__(175);
-	var focusNode = __webpack_require__(123);
-	var getActiveElement = __webpack_require__(178);
+	var containsNode = __webpack_require__(177);
+	var focusNode = __webpack_require__(122);
+	var getActiveElement = __webpack_require__(180);
 
 	function isInDocument(node) {
 	  return containsNode(document.documentElement, node);
@@ -24096,7 +24242,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactInputSelection;
 
 /***/ },
-/* 173 */
+/* 175 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -24107,14 +24253,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMSelection
 	 */
 
 	'use strict';
 
-	var ExecutionEnvironment = __webpack_require__(82);
+	var ExecutionEnvironment = __webpack_require__(81);
 
-	var getNodeForCharacterOffset = __webpack_require__(174);
+	var getNodeForCharacterOffset = __webpack_require__(176);
 	var getTextContentAccessor = __webpack_require__(84);
 
 	/**
@@ -24313,7 +24458,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMSelection;
 
 /***/ },
-/* 174 */
+/* 176 */
 /***/ function(module, exports) {
 
 	/**
@@ -24324,7 +24469,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getNodeForCharacterOffset
 	 */
 
 	'use strict';
@@ -24392,7 +24536,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getNodeForCharacterOffset;
 
 /***/ },
-/* 175 */
+/* 177 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -24408,7 +24552,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * 
 	 */
 
-	var isTextNode = __webpack_require__(176);
+	var isTextNode = __webpack_require__(178);
 
 	/*eslint-disable no-bitwise */
 
@@ -24436,7 +24580,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = containsNode;
 
 /***/ },
-/* 176 */
+/* 178 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -24452,7 +24596,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @typechecks
 	 */
 
-	var isNode = __webpack_require__(177);
+	var isNode = __webpack_require__(179);
 
 	/**
 	 * @param {*} object The object to check.
@@ -24465,7 +24609,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = isTextNode;
 
 /***/ },
-/* 177 */
+/* 179 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -24495,7 +24639,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = isNode;
 
 /***/ },
-/* 178 */
+/* 180 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -24535,7 +24679,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getActiveElement;
 
 /***/ },
-/* 179 */
+/* 181 */
 /***/ function(module, exports) {
 
 	/**
@@ -24546,7 +24690,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SVGDOMPropertyConfig
 	 */
 
 	'use strict';
@@ -24842,7 +24985,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SVGDOMPropertyConfig;
 
 /***/ },
-/* 180 */
+/* 182 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -24853,34 +24996,29 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SelectEventPlugin
 	 */
 
 	'use strict';
 
-	var EventConstants = __webpack_require__(74);
-	var EventPropagators = __webpack_require__(75);
-	var ExecutionEnvironment = __webpack_require__(82);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactInputSelection = __webpack_require__(172);
+	var EventPropagators = __webpack_require__(74);
+	var ExecutionEnvironment = __webpack_require__(81);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactInputSelection = __webpack_require__(174);
 	var SyntheticEvent = __webpack_require__(86);
 
-	var getActiveElement = __webpack_require__(178);
+	var getActiveElement = __webpack_require__(180);
 	var isTextInputElement = __webpack_require__(99);
-	var keyOf = __webpack_require__(25);
-	var shallowEqual = __webpack_require__(154);
-
-	var topLevelTypes = EventConstants.topLevelTypes;
+	var shallowEqual = __webpack_require__(150);
 
 	var skipSelectionChangeEvent = ExecutionEnvironment.canUseDOM && 'documentMode' in document && document.documentMode <= 11;
 
 	var eventTypes = {
 	  select: {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onSelect: null }),
-	      captured: keyOf({ onSelectCapture: null })
+	      bubbled: 'onSelect',
+	      captured: 'onSelectCapture'
 	    },
-	    dependencies: [topLevelTypes.topBlur, topLevelTypes.topContextMenu, topLevelTypes.topFocus, topLevelTypes.topKeyDown, topLevelTypes.topKeyUp, topLevelTypes.topMouseDown, topLevelTypes.topMouseUp, topLevelTypes.topSelectionChange]
+	    dependencies: ['topBlur', 'topContextMenu', 'topFocus', 'topKeyDown', 'topKeyUp', 'topMouseDown', 'topMouseUp', 'topSelectionChange']
 	  }
 	};
 
@@ -24892,7 +25030,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	// Track whether a listener exists for this plugin. If none exist, we do
 	// not extract events. See #3639.
 	var hasListener = false;
-	var ON_SELECT_KEY = keyOf({ onSelect: null });
 
 	/**
 	 * Get an object which is a unique representation of the current selection.
@@ -24988,14 +25125,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    switch (topLevelType) {
 	      // Track the input node that has focus.
-	      case topLevelTypes.topFocus:
+	      case 'topFocus':
 	        if (isTextInputElement(targetNode) || targetNode.contentEditable === 'true') {
 	          activeElement = targetNode;
 	          activeElementInst = targetInst;
 	          lastSelection = null;
 	        }
 	        break;
-	      case topLevelTypes.topBlur:
+	      case 'topBlur':
 	        activeElement = null;
 	        activeElementInst = null;
 	        lastSelection = null;
@@ -25003,11 +25140,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      // Don't fire the event while the user is dragging. This matches the
 	      // semantics of the native select event.
-	      case topLevelTypes.topMouseDown:
+	      case 'topMouseDown':
 	        mouseDown = true;
 	        break;
-	      case topLevelTypes.topContextMenu:
-	      case topLevelTypes.topMouseUp:
+	      case 'topContextMenu':
+	      case 'topMouseUp':
 	        mouseDown = false;
 	        return constructSelectEvent(nativeEvent, nativeEventTarget);
 
@@ -25020,13 +25157,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // keyup, but we check on keydown as well in the case of holding down a
 	      // key, when multiple keydown events are fired but only one keyup is.
 	      // This is also our approach for IE handling, for the reason above.
-	      case topLevelTypes.topSelectionChange:
+	      case 'topSelectionChange':
 	        if (skipSelectionChangeEvent) {
 	          break;
 	        }
 	      // falls through
-	      case topLevelTypes.topKeyDown:
-	      case topLevelTypes.topKeyUp:
+	      case 'topKeyDown':
+	      case 'topKeyUp':
 	        return constructSelectEvent(nativeEvent, nativeEventTarget);
 	    }
 
@@ -25034,7 +25171,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 
 	  didPutListener: function didPutListener(inst, registrationName, listener) {
-	    if (registrationName === ON_SELECT_KEY) {
+	    if (registrationName === 'onSelect') {
 	      hasListener = true;
 	    }
 	  }
@@ -25043,7 +25180,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SelectEventPlugin;
 
 /***/ },
-/* 181 */
+/* 183 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25054,489 +25191,78 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SimpleEventPlugin
+	 * 
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
-	var EventConstants = __webpack_require__(74);
-	var EventListener = __webpack_require__(168);
-	var EventPropagators = __webpack_require__(75);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var SyntheticAnimationEvent = __webpack_require__(182);
-	var SyntheticClipboardEvent = __webpack_require__(183);
+	var EventListener = __webpack_require__(170);
+	var EventPropagators = __webpack_require__(74);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var SyntheticAnimationEvent = __webpack_require__(184);
+	var SyntheticClipboardEvent = __webpack_require__(185);
 	var SyntheticEvent = __webpack_require__(86);
-	var SyntheticFocusEvent = __webpack_require__(184);
-	var SyntheticKeyboardEvent = __webpack_require__(185);
+	var SyntheticFocusEvent = __webpack_require__(186);
+	var SyntheticKeyboardEvent = __webpack_require__(187);
 	var SyntheticMouseEvent = __webpack_require__(102);
-	var SyntheticDragEvent = __webpack_require__(188);
-	var SyntheticTouchEvent = __webpack_require__(189);
-	var SyntheticTransitionEvent = __webpack_require__(190);
+	var SyntheticDragEvent = __webpack_require__(190);
+	var SyntheticTouchEvent = __webpack_require__(191);
+	var SyntheticTransitionEvent = __webpack_require__(192);
 	var SyntheticUIEvent = __webpack_require__(103);
-	var SyntheticWheelEvent = __webpack_require__(191);
+	var SyntheticWheelEvent = __webpack_require__(193);
 
 	var emptyFunction = __webpack_require__(12);
-	var getEventCharCode = __webpack_require__(186);
+	var getEventCharCode = __webpack_require__(188);
 	var invariant = __webpack_require__(8);
-	var keyOf = __webpack_require__(25);
 
-	var topLevelTypes = EventConstants.topLevelTypes;
+	/**
+	 * Turns
+	 * ['abort', ...]
+	 * into
+	 * eventTypes = {
+	 *   'abort': {
+	 *     phasedRegistrationNames: {
+	 *       bubbled: 'onAbort',
+	 *       captured: 'onAbortCapture',
+	 *     },
+	 *     dependencies: ['topAbort'],
+	 *   },
+	 *   ...
+	 * };
+	 * topLevelEventsToDispatchConfig = {
+	 *   'topAbort': { sameConfig }
+	 * };
+	 */
+	var eventTypes = {};
+	var topLevelEventsToDispatchConfig = {};
+	['abort', 'animationEnd', 'animationIteration', 'animationStart', 'blur', 'canPlay', 'canPlayThrough', 'click', 'contextMenu', 'copy', 'cut', 'doubleClick', 'drag', 'dragEnd', 'dragEnter', 'dragExit', 'dragLeave', 'dragOver', 'dragStart', 'drop', 'durationChange', 'emptied', 'encrypted', 'ended', 'error', 'focus', 'input', 'invalid', 'keyDown', 'keyPress', 'keyUp', 'load', 'loadedData', 'loadedMetadata', 'loadStart', 'mouseDown', 'mouseMove', 'mouseOut', 'mouseOver', 'mouseUp', 'paste', 'pause', 'play', 'playing', 'progress', 'rateChange', 'reset', 'scroll', 'seeked', 'seeking', 'stalled', 'submit', 'suspend', 'timeUpdate', 'touchCancel', 'touchEnd', 'touchMove', 'touchStart', 'transitionEnd', 'volumeChange', 'waiting', 'wheel'].forEach(function (event) {
+	  var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+	  var onEvent = 'on' + capitalizedEvent;
+	  var topEvent = 'top' + capitalizedEvent;
 
-	var eventTypes = {
-	  abort: {
+	  var type = {
 	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onAbort: true }),
-	      captured: keyOf({ onAbortCapture: true })
-	    }
-	  },
-	  animationEnd: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onAnimationEnd: true }),
-	      captured: keyOf({ onAnimationEndCapture: true })
-	    }
-	  },
-	  animationIteration: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onAnimationIteration: true }),
-	      captured: keyOf({ onAnimationIterationCapture: true })
-	    }
-	  },
-	  animationStart: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onAnimationStart: true }),
-	      captured: keyOf({ onAnimationStartCapture: true })
-	    }
-	  },
-	  blur: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onBlur: true }),
-	      captured: keyOf({ onBlurCapture: true })
-	    }
-	  },
-	  canPlay: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCanPlay: true }),
-	      captured: keyOf({ onCanPlayCapture: true })
-	    }
-	  },
-	  canPlayThrough: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCanPlayThrough: true }),
-	      captured: keyOf({ onCanPlayThroughCapture: true })
-	    }
-	  },
-	  click: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onClick: true }),
-	      captured: keyOf({ onClickCapture: true })
-	    }
-	  },
-	  contextMenu: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onContextMenu: true }),
-	      captured: keyOf({ onContextMenuCapture: true })
-	    }
-	  },
-	  copy: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCopy: true }),
-	      captured: keyOf({ onCopyCapture: true })
-	    }
-	  },
-	  cut: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onCut: true }),
-	      captured: keyOf({ onCutCapture: true })
-	    }
-	  },
-	  doubleClick: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDoubleClick: true }),
-	      captured: keyOf({ onDoubleClickCapture: true })
-	    }
-	  },
-	  drag: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDrag: true }),
-	      captured: keyOf({ onDragCapture: true })
-	    }
-	  },
-	  dragEnd: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragEnd: true }),
-	      captured: keyOf({ onDragEndCapture: true })
-	    }
-	  },
-	  dragEnter: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragEnter: true }),
-	      captured: keyOf({ onDragEnterCapture: true })
-	    }
-	  },
-	  dragExit: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragExit: true }),
-	      captured: keyOf({ onDragExitCapture: true })
-	    }
-	  },
-	  dragLeave: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragLeave: true }),
-	      captured: keyOf({ onDragLeaveCapture: true })
-	    }
-	  },
-	  dragOver: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragOver: true }),
-	      captured: keyOf({ onDragOverCapture: true })
-	    }
-	  },
-	  dragStart: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDragStart: true }),
-	      captured: keyOf({ onDragStartCapture: true })
-	    }
-	  },
-	  drop: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDrop: true }),
-	      captured: keyOf({ onDropCapture: true })
-	    }
-	  },
-	  durationChange: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onDurationChange: true }),
-	      captured: keyOf({ onDurationChangeCapture: true })
-	    }
-	  },
-	  emptied: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onEmptied: true }),
-	      captured: keyOf({ onEmptiedCapture: true })
-	    }
-	  },
-	  encrypted: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onEncrypted: true }),
-	      captured: keyOf({ onEncryptedCapture: true })
-	    }
-	  },
-	  ended: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onEnded: true }),
-	      captured: keyOf({ onEndedCapture: true })
-	    }
-	  },
-	  error: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onError: true }),
-	      captured: keyOf({ onErrorCapture: true })
-	    }
-	  },
-	  focus: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onFocus: true }),
-	      captured: keyOf({ onFocusCapture: true })
-	    }
-	  },
-	  input: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onInput: true }),
-	      captured: keyOf({ onInputCapture: true })
-	    }
-	  },
-	  invalid: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onInvalid: true }),
-	      captured: keyOf({ onInvalidCapture: true })
-	    }
-	  },
-	  keyDown: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onKeyDown: true }),
-	      captured: keyOf({ onKeyDownCapture: true })
-	    }
-	  },
-	  keyPress: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onKeyPress: true }),
-	      captured: keyOf({ onKeyPressCapture: true })
-	    }
-	  },
-	  keyUp: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onKeyUp: true }),
-	      captured: keyOf({ onKeyUpCapture: true })
-	    }
-	  },
-	  load: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onLoad: true }),
-	      captured: keyOf({ onLoadCapture: true })
-	    }
-	  },
-	  loadedData: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onLoadedData: true }),
-	      captured: keyOf({ onLoadedDataCapture: true })
-	    }
-	  },
-	  loadedMetadata: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onLoadedMetadata: true }),
-	      captured: keyOf({ onLoadedMetadataCapture: true })
-	    }
-	  },
-	  loadStart: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onLoadStart: true }),
-	      captured: keyOf({ onLoadStartCapture: true })
-	    }
-	  },
-	  // Note: We do not allow listening to mouseOver events. Instead, use the
-	  // onMouseEnter/onMouseLeave created by `EnterLeaveEventPlugin`.
-	  mouseDown: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onMouseDown: true }),
-	      captured: keyOf({ onMouseDownCapture: true })
-	    }
-	  },
-	  mouseMove: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onMouseMove: true }),
-	      captured: keyOf({ onMouseMoveCapture: true })
-	    }
-	  },
-	  mouseOut: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onMouseOut: true }),
-	      captured: keyOf({ onMouseOutCapture: true })
-	    }
-	  },
-	  mouseOver: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onMouseOver: true }),
-	      captured: keyOf({ onMouseOverCapture: true })
-	    }
-	  },
-	  mouseUp: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onMouseUp: true }),
-	      captured: keyOf({ onMouseUpCapture: true })
-	    }
-	  },
-	  paste: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onPaste: true }),
-	      captured: keyOf({ onPasteCapture: true })
-	    }
-	  },
-	  pause: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onPause: true }),
-	      captured: keyOf({ onPauseCapture: true })
-	    }
-	  },
-	  play: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onPlay: true }),
-	      captured: keyOf({ onPlayCapture: true })
-	    }
-	  },
-	  playing: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onPlaying: true }),
-	      captured: keyOf({ onPlayingCapture: true })
-	    }
-	  },
-	  progress: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onProgress: true }),
-	      captured: keyOf({ onProgressCapture: true })
-	    }
-	  },
-	  rateChange: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onRateChange: true }),
-	      captured: keyOf({ onRateChangeCapture: true })
-	    }
-	  },
-	  reset: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onReset: true }),
-	      captured: keyOf({ onResetCapture: true })
-	    }
-	  },
-	  scroll: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onScroll: true }),
-	      captured: keyOf({ onScrollCapture: true })
-	    }
-	  },
-	  seeked: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onSeeked: true }),
-	      captured: keyOf({ onSeekedCapture: true })
-	    }
-	  },
-	  seeking: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onSeeking: true }),
-	      captured: keyOf({ onSeekingCapture: true })
-	    }
-	  },
-	  stalled: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onStalled: true }),
-	      captured: keyOf({ onStalledCapture: true })
-	    }
-	  },
-	  submit: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onSubmit: true }),
-	      captured: keyOf({ onSubmitCapture: true })
-	    }
-	  },
-	  suspend: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onSuspend: true }),
-	      captured: keyOf({ onSuspendCapture: true })
-	    }
-	  },
-	  timeUpdate: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTimeUpdate: true }),
-	      captured: keyOf({ onTimeUpdateCapture: true })
-	    }
-	  },
-	  touchCancel: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTouchCancel: true }),
-	      captured: keyOf({ onTouchCancelCapture: true })
-	    }
-	  },
-	  touchEnd: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTouchEnd: true }),
-	      captured: keyOf({ onTouchEndCapture: true })
-	    }
-	  },
-	  touchMove: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTouchMove: true }),
-	      captured: keyOf({ onTouchMoveCapture: true })
-	    }
-	  },
-	  touchStart: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTouchStart: true }),
-	      captured: keyOf({ onTouchStartCapture: true })
-	    }
-	  },
-	  transitionEnd: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onTransitionEnd: true }),
-	      captured: keyOf({ onTransitionEndCapture: true })
-	    }
-	  },
-	  volumeChange: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onVolumeChange: true }),
-	      captured: keyOf({ onVolumeChangeCapture: true })
-	    }
-	  },
-	  waiting: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onWaiting: true }),
-	      captured: keyOf({ onWaitingCapture: true })
-	    }
-	  },
-	  wheel: {
-	    phasedRegistrationNames: {
-	      bubbled: keyOf({ onWheel: true }),
-	      captured: keyOf({ onWheelCapture: true })
-	    }
-	  }
-	};
+	      bubbled: onEvent,
+	      captured: onEvent + 'Capture'
+	    },
+	    dependencies: [topEvent]
+	  };
+	  eventTypes[event] = type;
+	  topLevelEventsToDispatchConfig[topEvent] = type;
+	});
 
-	var topLevelEventsToDispatchConfig = {
-	  topAbort: eventTypes.abort,
-	  topAnimationEnd: eventTypes.animationEnd,
-	  topAnimationIteration: eventTypes.animationIteration,
-	  topAnimationStart: eventTypes.animationStart,
-	  topBlur: eventTypes.blur,
-	  topCanPlay: eventTypes.canPlay,
-	  topCanPlayThrough: eventTypes.canPlayThrough,
-	  topClick: eventTypes.click,
-	  topContextMenu: eventTypes.contextMenu,
-	  topCopy: eventTypes.copy,
-	  topCut: eventTypes.cut,
-	  topDoubleClick: eventTypes.doubleClick,
-	  topDrag: eventTypes.drag,
-	  topDragEnd: eventTypes.dragEnd,
-	  topDragEnter: eventTypes.dragEnter,
-	  topDragExit: eventTypes.dragExit,
-	  topDragLeave: eventTypes.dragLeave,
-	  topDragOver: eventTypes.dragOver,
-	  topDragStart: eventTypes.dragStart,
-	  topDrop: eventTypes.drop,
-	  topDurationChange: eventTypes.durationChange,
-	  topEmptied: eventTypes.emptied,
-	  topEncrypted: eventTypes.encrypted,
-	  topEnded: eventTypes.ended,
-	  topError: eventTypes.error,
-	  topFocus: eventTypes.focus,
-	  topInput: eventTypes.input,
-	  topInvalid: eventTypes.invalid,
-	  topKeyDown: eventTypes.keyDown,
-	  topKeyPress: eventTypes.keyPress,
-	  topKeyUp: eventTypes.keyUp,
-	  topLoad: eventTypes.load,
-	  topLoadedData: eventTypes.loadedData,
-	  topLoadedMetadata: eventTypes.loadedMetadata,
-	  topLoadStart: eventTypes.loadStart,
-	  topMouseDown: eventTypes.mouseDown,
-	  topMouseMove: eventTypes.mouseMove,
-	  topMouseOut: eventTypes.mouseOut,
-	  topMouseOver: eventTypes.mouseOver,
-	  topMouseUp: eventTypes.mouseUp,
-	  topPaste: eventTypes.paste,
-	  topPause: eventTypes.pause,
-	  topPlay: eventTypes.play,
-	  topPlaying: eventTypes.playing,
-	  topProgress: eventTypes.progress,
-	  topRateChange: eventTypes.rateChange,
-	  topReset: eventTypes.reset,
-	  topScroll: eventTypes.scroll,
-	  topSeeked: eventTypes.seeked,
-	  topSeeking: eventTypes.seeking,
-	  topStalled: eventTypes.stalled,
-	  topSubmit: eventTypes.submit,
-	  topSuspend: eventTypes.suspend,
-	  topTimeUpdate: eventTypes.timeUpdate,
-	  topTouchCancel: eventTypes.touchCancel,
-	  topTouchEnd: eventTypes.touchEnd,
-	  topTouchMove: eventTypes.touchMove,
-	  topTouchStart: eventTypes.touchStart,
-	  topTransitionEnd: eventTypes.transitionEnd,
-	  topVolumeChange: eventTypes.volumeChange,
-	  topWaiting: eventTypes.waiting,
-	  topWheel: eventTypes.wheel
-	};
-
-	for (var type in topLevelEventsToDispatchConfig) {
-	  topLevelEventsToDispatchConfig[type].dependencies = [type];
-	}
-
-	var ON_CLICK_KEY = keyOf({ onClick: null });
 	var onClickListeners = {};
 
 	function getDictionaryKey(inst) {
 	  // Prevents V8 performance issue:
 	  // https://github.com/facebook/react/pull/7232
 	  return '.' + inst._rootNodeID;
+	}
+
+	function isInteractive(tag) {
+	  return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
 	}
 
 	var SimpleEventPlugin = {
@@ -25550,39 +25276,39 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    var EventConstructor;
 	    switch (topLevelType) {
-	      case topLevelTypes.topAbort:
-	      case topLevelTypes.topCanPlay:
-	      case topLevelTypes.topCanPlayThrough:
-	      case topLevelTypes.topDurationChange:
-	      case topLevelTypes.topEmptied:
-	      case topLevelTypes.topEncrypted:
-	      case topLevelTypes.topEnded:
-	      case topLevelTypes.topError:
-	      case topLevelTypes.topInput:
-	      case topLevelTypes.topInvalid:
-	      case topLevelTypes.topLoad:
-	      case topLevelTypes.topLoadedData:
-	      case topLevelTypes.topLoadedMetadata:
-	      case topLevelTypes.topLoadStart:
-	      case topLevelTypes.topPause:
-	      case topLevelTypes.topPlay:
-	      case topLevelTypes.topPlaying:
-	      case topLevelTypes.topProgress:
-	      case topLevelTypes.topRateChange:
-	      case topLevelTypes.topReset:
-	      case topLevelTypes.topSeeked:
-	      case topLevelTypes.topSeeking:
-	      case topLevelTypes.topStalled:
-	      case topLevelTypes.topSubmit:
-	      case topLevelTypes.topSuspend:
-	      case topLevelTypes.topTimeUpdate:
-	      case topLevelTypes.topVolumeChange:
-	      case topLevelTypes.topWaiting:
+	      case 'topAbort':
+	      case 'topCanPlay':
+	      case 'topCanPlayThrough':
+	      case 'topDurationChange':
+	      case 'topEmptied':
+	      case 'topEncrypted':
+	      case 'topEnded':
+	      case 'topError':
+	      case 'topInput':
+	      case 'topInvalid':
+	      case 'topLoad':
+	      case 'topLoadedData':
+	      case 'topLoadedMetadata':
+	      case 'topLoadStart':
+	      case 'topPause':
+	      case 'topPlay':
+	      case 'topPlaying':
+	      case 'topProgress':
+	      case 'topRateChange':
+	      case 'topReset':
+	      case 'topSeeked':
+	      case 'topSeeking':
+	      case 'topStalled':
+	      case 'topSubmit':
+	      case 'topSuspend':
+	      case 'topTimeUpdate':
+	      case 'topVolumeChange':
+	      case 'topWaiting':
 	        // HTML Events
 	        // @see http://www.w3.org/TR/html5/index.html#events-0
 	        EventConstructor = SyntheticEvent;
 	        break;
-	      case topLevelTypes.topKeyPress:
+	      case 'topKeyPress':
 	        // Firefox creates a keypress event for function keys too. This removes
 	        // the unwanted keypress events. Enter is however both printable and
 	        // non-printable. One would expect Tab to be as well (but it isn't).
@@ -25590,63 +25316,65 @@ return /******/ (function(modules) { // webpackBootstrap
 	          return null;
 	        }
 	      /* falls through */
-	      case topLevelTypes.topKeyDown:
-	      case topLevelTypes.topKeyUp:
+	      case 'topKeyDown':
+	      case 'topKeyUp':
 	        EventConstructor = SyntheticKeyboardEvent;
 	        break;
-	      case topLevelTypes.topBlur:
-	      case topLevelTypes.topFocus:
+	      case 'topBlur':
+	      case 'topFocus':
 	        EventConstructor = SyntheticFocusEvent;
 	        break;
-	      case topLevelTypes.topClick:
+	      case 'topClick':
 	        // Firefox creates a click event on right mouse clicks. This removes the
 	        // unwanted click events.
 	        if (nativeEvent.button === 2) {
 	          return null;
 	        }
 	      /* falls through */
-	      case topLevelTypes.topContextMenu:
-	      case topLevelTypes.topDoubleClick:
-	      case topLevelTypes.topMouseDown:
-	      case topLevelTypes.topMouseMove:
-	      case topLevelTypes.topMouseOut:
-	      case topLevelTypes.topMouseOver:
-	      case topLevelTypes.topMouseUp:
+	      case 'topDoubleClick':
+	      case 'topMouseDown':
+	      case 'topMouseMove':
+	      case 'topMouseUp':
+	      // TODO: Disabled elements should not respond to mouse events
+	      /* falls through */
+	      case 'topMouseOut':
+	      case 'topMouseOver':
+	      case 'topContextMenu':
 	        EventConstructor = SyntheticMouseEvent;
 	        break;
-	      case topLevelTypes.topDrag:
-	      case topLevelTypes.topDragEnd:
-	      case topLevelTypes.topDragEnter:
-	      case topLevelTypes.topDragExit:
-	      case topLevelTypes.topDragLeave:
-	      case topLevelTypes.topDragOver:
-	      case topLevelTypes.topDragStart:
-	      case topLevelTypes.topDrop:
+	      case 'topDrag':
+	      case 'topDragEnd':
+	      case 'topDragEnter':
+	      case 'topDragExit':
+	      case 'topDragLeave':
+	      case 'topDragOver':
+	      case 'topDragStart':
+	      case 'topDrop':
 	        EventConstructor = SyntheticDragEvent;
 	        break;
-	      case topLevelTypes.topTouchCancel:
-	      case topLevelTypes.topTouchEnd:
-	      case topLevelTypes.topTouchMove:
-	      case topLevelTypes.topTouchStart:
+	      case 'topTouchCancel':
+	      case 'topTouchEnd':
+	      case 'topTouchMove':
+	      case 'topTouchStart':
 	        EventConstructor = SyntheticTouchEvent;
 	        break;
-	      case topLevelTypes.topAnimationEnd:
-	      case topLevelTypes.topAnimationIteration:
-	      case topLevelTypes.topAnimationStart:
+	      case 'topAnimationEnd':
+	      case 'topAnimationIteration':
+	      case 'topAnimationStart':
 	        EventConstructor = SyntheticAnimationEvent;
 	        break;
-	      case topLevelTypes.topTransitionEnd:
+	      case 'topTransitionEnd':
 	        EventConstructor = SyntheticTransitionEvent;
 	        break;
-	      case topLevelTypes.topScroll:
+	      case 'topScroll':
 	        EventConstructor = SyntheticUIEvent;
 	        break;
-	      case topLevelTypes.topWheel:
+	      case 'topWheel':
 	        EventConstructor = SyntheticWheelEvent;
 	        break;
-	      case topLevelTypes.topCopy:
-	      case topLevelTypes.topCut:
-	      case topLevelTypes.topPaste:
+	      case 'topCopy':
+	      case 'topCut':
+	      case 'topPaste':
 	        EventConstructor = SyntheticClipboardEvent;
 	        break;
 	    }
@@ -25661,7 +25389,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    // non-interactive elements, which means delegated click listeners do not
 	    // fire. The workaround for this bug involves attaching an empty click
 	    // listener on the target node.
-	    if (registrationName === ON_CLICK_KEY) {
+	    // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+	    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
 	      var key = getDictionaryKey(inst);
 	      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
 	      if (!onClickListeners[key]) {
@@ -25671,7 +25400,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  },
 
 	  willDeleteListener: function willDeleteListener(inst, registrationName) {
-	    if (registrationName === ON_CLICK_KEY) {
+	    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
 	      var key = getDictionaryKey(inst);
 	      onClickListeners[key].remove();
 	      delete onClickListeners[key];
@@ -25683,7 +25412,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SimpleEventPlugin;
 
 /***/ },
-/* 182 */
+/* 184 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25694,7 +25423,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticAnimationEvent
 	 */
 
 	'use strict';
@@ -25727,7 +25455,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticAnimationEvent;
 
 /***/ },
-/* 183 */
+/* 185 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25738,7 +25466,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticClipboardEvent
 	 */
 
 	'use strict';
@@ -25770,7 +25497,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticClipboardEvent;
 
 /***/ },
-/* 184 */
+/* 186 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25781,7 +25508,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticFocusEvent
 	 */
 
 	'use strict';
@@ -25811,7 +25537,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticFocusEvent;
 
 /***/ },
-/* 185 */
+/* 187 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25822,15 +25548,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticKeyboardEvent
 	 */
 
 	'use strict';
 
 	var SyntheticUIEvent = __webpack_require__(103);
 
-	var getEventCharCode = __webpack_require__(186);
-	var getEventKey = __webpack_require__(187);
+	var getEventCharCode = __webpack_require__(188);
+	var getEventKey = __webpack_require__(189);
 	var getEventModifierState = __webpack_require__(105);
 
 	/**
@@ -25900,7 +25625,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticKeyboardEvent;
 
 /***/ },
-/* 186 */
+/* 188 */
 /***/ function(module, exports) {
 
 	/**
@@ -25911,7 +25636,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getEventCharCode
 	 */
 
 	'use strict';
@@ -25955,7 +25679,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getEventCharCode;
 
 /***/ },
-/* 187 */
+/* 189 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -25966,12 +25690,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getEventKey
 	 */
 
 	'use strict';
 
-	var getEventCharCode = __webpack_require__(186);
+	var getEventCharCode = __webpack_require__(188);
 
 	/**
 	 * Normalization of deprecated HTML5 `key` values
@@ -26062,7 +25785,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getEventKey;
 
 /***/ },
-/* 188 */
+/* 190 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26073,7 +25796,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticDragEvent
 	 */
 
 	'use strict';
@@ -26103,7 +25825,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticDragEvent;
 
 /***/ },
-/* 189 */
+/* 191 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26114,7 +25836,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticTouchEvent
 	 */
 
 	'use strict';
@@ -26153,7 +25874,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticTouchEvent;
 
 /***/ },
-/* 190 */
+/* 192 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26164,7 +25885,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticTransitionEvent
 	 */
 
 	'use strict';
@@ -26197,7 +25917,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticTransitionEvent;
 
 /***/ },
-/* 191 */
+/* 193 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26208,7 +25928,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule SyntheticWheelEvent
 	 */
 
 	'use strict';
@@ -26256,7 +25975,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = SyntheticWheelEvent;
 
 /***/ },
-/* 192 */
+/* 194 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26267,34 +25986,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactMount
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var DOMLazyTree = __webpack_require__(109);
-	var DOMProperty = __webpack_require__(70);
-	var ReactBrowserEventEmitter = __webpack_require__(134);
+	var DOMProperty = __webpack_require__(69);
+	var React = __webpack_require__(3);
+	var ReactBrowserEventEmitter = __webpack_require__(133);
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactDOMContainerInfo = __webpack_require__(193);
-	var ReactDOMFeatureFlags = __webpack_require__(194);
-	var ReactElement = __webpack_require__(9);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactDOMContainerInfo = __webpack_require__(195);
+	var ReactDOMFeatureFlags = __webpack_require__(196);
 	var ReactFeatureFlags = __webpack_require__(91);
-	var ReactInstanceMap = __webpack_require__(146);
+	var ReactInstanceMap = __webpack_require__(144);
 	var ReactInstrumentation = __webpack_require__(95);
-	var ReactMarkupChecksum = __webpack_require__(195);
+	var ReactMarkupChecksum = __webpack_require__(197);
 	var ReactReconciler = __webpack_require__(92);
-	var ReactUpdateQueue = __webpack_require__(161);
+	var ReactUpdateQueue = __webpack_require__(163);
 	var ReactUpdates = __webpack_require__(89);
 
-	var emptyObject = __webpack_require__(19);
-	var instantiateReactComponent = __webpack_require__(149);
+	var emptyObject = __webpack_require__(20);
+	var instantiateReactComponent = __webpack_require__(147);
 	var invariant = __webpack_require__(8);
 	var setInnerHTML = __webpack_require__(111);
-	var shouldUpdateReactComponent = __webpack_require__(155);
+	var shouldUpdateReactComponent = __webpack_require__(151);
 	var warning = __webpack_require__(11);
 
 	var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
@@ -26357,7 +26075,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function mountComponentIntoNode(wrapperInstance, container, transaction, shouldReuseMarkup, context) {
 	  var markerName;
 	  if (ReactFeatureFlags.logTopLevelRenders) {
-	    var wrappedElement = wrapperInstance._currentElement.props;
+	    var wrappedElement = wrapperInstance._currentElement.props.child;
 	    var type = wrappedElement.type;
 	    markerName = 'React mount: ' + (typeof type === 'string' ? type : type.displayName || type.name);
 	    console.time(markerName);
@@ -26495,9 +26213,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  TopLevelWrapper.displayName = 'TopLevelWrapper';
 	}
 	TopLevelWrapper.prototype.render = function () {
-	  // this.props is actually a ReactElement
-	  return this.props;
+	  return this.props.child;
 	};
+	TopLevelWrapper.isReactTopLevelWrapper = true;
 
 	/**
 	 * Mounting is the process of initializing a React component by creating its
@@ -26607,13 +26325,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  _renderSubtreeIntoContainer: function _renderSubtreeIntoContainer(parentComponent, nextElement, container, callback) {
 	    ReactUpdateQueue.validateCallback(callback, 'ReactDOM.render');
-	    !ReactElement.isValidElement(nextElement) ?  false ? invariant(false, 'ReactDOM.render(): Invalid component element.%s', typeof nextElement === 'string' ? ' Instead of passing a string like \'div\', pass ' + 'React.createElement(\'div\') or <div />.' : typeof nextElement === 'function' ? ' Instead of passing a class like Foo, pass ' + 'React.createElement(Foo) or <Foo />.' :
+	    !React.isValidElement(nextElement) ?  false ? invariant(false, 'ReactDOM.render(): Invalid component element.%s', typeof nextElement === 'string' ? ' Instead of passing a string like \'div\', pass ' + 'React.createElement(\'div\') or <div />.' : typeof nextElement === 'function' ? ' Instead of passing a class like Foo, pass ' + 'React.createElement(Foo) or <Foo />.' :
 	    // Check if it quacks like an element
 	    nextElement != null && nextElement.props !== undefined ? ' This may be caused by unintentionally loading two independent ' + 'copies of React.' : '') : _prodInvariant('39', typeof nextElement === 'string' ? ' Instead of passing a string like \'div\', pass ' + 'React.createElement(\'div\') or <div />.' : typeof nextElement === 'function' ? ' Instead of passing a class like Foo, pass ' + 'React.createElement(Foo) or <Foo />.' : nextElement != null && nextElement.props !== undefined ? ' This may be caused by unintentionally loading two independent ' + 'copies of React.' : '') : void 0;
 
 	     false ? warning(!container || !container.tagName || container.tagName.toUpperCase() !== 'BODY', 'render(): Rendering components directly into document.body is ' + 'discouraged, since its children are often manipulated by third-party ' + 'scripts and browser extensions. This may lead to subtle ' + 'reconciliation issues. Try rendering into a container element created ' + 'for your app.') : void 0;
 
-	    var nextWrappedElement = ReactElement(TopLevelWrapper, null, null, null, null, null, nextElement);
+	    var nextWrappedElement = React.createElement(TopLevelWrapper, { child: nextElement });
 
 	    var nextContext;
 	    if (parentComponent) {
@@ -26627,7 +26345,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    if (prevComponent) {
 	      var prevWrappedElement = prevComponent._currentElement;
-	      var prevElement = prevWrappedElement.props;
+	      var prevElement = prevWrappedElement.props.child;
 	      if (shouldUpdateReactComponent(prevElement, nextElement)) {
 	        var publicInst = prevComponent._renderedComponent.getPublicInstance();
 	        var updatedCallback = callback && function () {
@@ -26786,7 +26504,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (false) {
 	      var hostNode = ReactDOMComponentTree.getInstanceFromNode(container.firstChild);
 	      if (hostNode._debugID !== 0) {
-	        ReactInstrumentation.debugTool.onHostOperation(hostNode._debugID, 'mount', markup.toString());
+	        ReactInstrumentation.debugTool.onHostOperation({
+	          instanceID: hostNode._debugID,
+	          type: 'mount',
+	          payload: markup.toString()
+	        });
 	      }
 	    }
 	  }
@@ -26795,7 +26517,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactMount;
 
 /***/ },
-/* 193 */
+/* 195 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26806,12 +26528,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMContainerInfo
 	 */
 
 	'use strict';
 
-	var validateDOMNesting = __webpack_require__(162);
+	var validateDOMNesting = __webpack_require__(164);
 
 	var DOC_NODE_TYPE = 9;
 
@@ -26833,7 +26554,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactDOMContainerInfo;
 
 /***/ },
-/* 194 */
+/* 196 */
 /***/ function(module, exports) {
 
 	/**
@@ -26844,19 +26565,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactDOMFeatureFlags
 	 */
 
 	'use strict';
 
 	var ReactDOMFeatureFlags = {
-	  useCreateElement: true
+	  useCreateElement: true,
+	  useFiber: false
 	};
 
 	module.exports = ReactDOMFeatureFlags;
 
 /***/ },
-/* 195 */
+/* 197 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26867,12 +26588,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule ReactMarkupChecksum
 	 */
 
 	'use strict';
 
-	var adler32 = __webpack_require__(196);
+	var adler32 = __webpack_require__(198);
 
 	var TAG_END = /\/?>/;
 	var COMMENT_START = /^<\!\-\-/;
@@ -26911,7 +26631,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = ReactMarkupChecksum;
 
 /***/ },
-/* 196 */
+/* 198 */
 /***/ function(module, exports) {
 
 	/**
@@ -26922,7 +26642,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule adler32
 	 * 
 	 */
 
@@ -26960,7 +26679,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = adler32;
 
 /***/ },
-/* 197 */
+/* 199 */
+/***/ function(module, exports) {
+
+	/**
+	 * Copyright 2013-present, Facebook, Inc.
+	 * All rights reserved.
+	 *
+	 * This source code is licensed under the BSD-style license found in the
+	 * LICENSE file in the root directory of this source tree. An additional grant
+	 * of patent rights can be found in the PATENTS file in the same directory.
+	 *
+	 */
+
+	'use strict';
+
+	module.exports = '15.4.1';
+
+/***/ },
+/* 200 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -26971,18 +26708,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule findDOMNode
 	 */
 
 	'use strict';
 
-	var _prodInvariant = __webpack_require__(7);
+	var _prodInvariant = __webpack_require__(68);
 
 	var ReactCurrentOwner = __webpack_require__(10);
-	var ReactDOMComponentTree = __webpack_require__(69);
-	var ReactInstanceMap = __webpack_require__(146);
+	var ReactDOMComponentTree = __webpack_require__(67);
+	var ReactInstanceMap = __webpack_require__(144);
 
-	var getHostComponentFromComposite = __webpack_require__(198);
+	var getHostComponentFromComposite = __webpack_require__(201);
 	var invariant = __webpack_require__(8);
 	var warning = __webpack_require__(11);
 
@@ -27025,7 +26761,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = findDOMNode;
 
 /***/ },
-/* 198 */
+/* 201 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -27036,12 +26772,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	 * @providesModule getHostComponentFromComposite
 	 */
 
 	'use strict';
 
-	var ReactNodeTypes = __webpack_require__(151);
+	var ReactNodeTypes = __webpack_require__(149);
 
 	function getHostComponentFromComposite(inst) {
 	  var type;
@@ -27060,7 +26795,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = getHostComponentFromComposite;
 
 /***/ },
-/* 199 */
+/* 202 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
@@ -27071,17 +26806,160 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
-	* @providesModule renderSubtreeIntoContainer
-	*/
+	 */
 
 	'use strict';
 
-	var ReactMount = __webpack_require__(192);
+	var ReactMount = __webpack_require__(194);
 
 	module.exports = ReactMount.renderSubtreeIntoContainer;
 
 /***/ },
-/* 200 */
+/* 203 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+	var _react = __webpack_require__(2);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _axis = __webpack_require__(204);
+
+	var _axis2 = _interopRequireDefault(_axis);
+
+	var _barplot = __webpack_require__(205);
+
+	var _barplot2 = _interopRequireDefault(_barplot);
+
+	var _scatterplot = __webpack_require__(206);
+
+	var _scatterplot2 = _interopRequireDefault(_scatterplot);
+
+	var _theme = __webpack_require__(207);
+
+	var _theme2 = _interopRequireDefault(_theme);
+
+	var _jubilationTheme = __webpack_require__(37);
+
+	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+	var Examples = function (_Component) {
+	  _inherits(Examples, _Component);
+
+	  function Examples(props) {
+	    _classCallCheck(this, Examples);
+
+	    var _this = _possibleConstructorReturn(this, (Examples.__proto__ || Object.getPrototypeOf(Examples)).call(this, props));
+
+	    _this.updateTheme = _this.updateTheme.bind(_this);
+	    _this.updateLabelStyle = _this.updateLabelStyle.bind(_this);
+	    _this.updateMargin = _this.updateMargin.bind(_this);
+
+	    _this.state = {
+	      theme: _jubilationTheme2.default
+	    };
+	    return _this;
+	  }
+
+	  _createClass(Examples, [{
+	    key: 'updateTheme',
+	    value: function updateTheme(event, attr) {
+	      var newAttrValue = event.target.value;
+	      this.setState(function (oldState) {
+	        return {
+	          theme: _extends({}, oldState.theme, _defineProperty({}, attr, newAttrValue))
+	        };
+	      });
+	    }
+	  }, {
+	    key: 'updateLabelStyle',
+	    value: function updateLabelStyle(event, type) {
+	      var newAttrValue = Number(event.target.value) || event.target.value;
+	      this.setState(function (oldState) {
+	        return {
+	          theme: _extends({}, oldState.theme, {
+	            labelStyle: _extends({}, oldState.theme.labelStyle, _defineProperty({}, type, newAttrValue))
+	          })
+	        };
+	      });
+	    }
+	  }, {
+	    key: 'updateMargin',
+	    value: function updateMargin(event, type) {
+	      var newAttrValue = Number(event.target.value) || event.target.value;
+	      this.setState(function (oldState) {
+	        return {
+	          theme: _extends({}, oldState.theme, {
+	            margin: _extends({}, oldState.theme.margin, _defineProperty({}, type, newAttrValue))
+	          })
+	        };
+	      });
+	    }
+	  }, {
+	    key: 'render',
+	    value: function render() {
+	      var handlers = {
+	        updateLabelStyle: this.updateLabelStyle,
+	        updateMargin: this.updateMargin,
+	        updateTheme: this.updateTheme
+	      };
+	      var theme = this.state.theme;
+
+
+	      return _react2.default.createElement(
+	        'div',
+	        null,
+	        _react2.default.createElement(_theme2.default, _extends({ theme: theme }, handlers)),
+	        _react2.default.createElement(
+	          'h1',
+	          null,
+	          'Axis Examples'
+	        ),
+	        _react2.default.createElement(_axis2.default, { theme: theme }),
+	        _react2.default.createElement(
+	          'h1',
+	          null,
+	          'Bar Plot Examples'
+	        ),
+	        _react2.default.createElement(_barplot2.default, { theme: theme }),
+	        _react2.default.createElement(
+	          'h1',
+	          null,
+	          'Scatter Plot Examples'
+	        ),
+	        _react2.default.createElement(_scatterplot2.default, { theme: theme })
+	      );
+	    }
+	  }]);
+
+	  return Examples;
+	}(_react.Component);
+
+	;
+
+	exports.default = Examples;
+
+/***/ },
+/* 204 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -27096,15 +26974,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationChart = __webpack_require__(35);
+	var _jubilationChart = __webpack_require__(33);
 
 	var _jubilationChart2 = _interopRequireDefault(_jubilationChart);
 
-	var _jubilationScatter = __webpack_require__(53);
+	var _jubilationScatter = __webpack_require__(51);
 
 	var _jubilationScatter2 = _interopRequireDefault(_jubilationScatter);
 
-	var _jubilationAxis = __webpack_require__(60);
+	var _jubilationAxis = __webpack_require__(58);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -27315,7 +27193,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = AxisExample;
 
 /***/ },
-/* 201 */
+/* 205 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -27330,23 +27208,23 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationChart = __webpack_require__(35);
+	var _jubilationChart = __webpack_require__(33);
 
 	var _jubilationChart2 = _interopRequireDefault(_jubilationChart);
 
-	var _jubilationHorizontalBar = __webpack_require__(55);
+	var _jubilationHorizontalBar = __webpack_require__(53);
 
 	var _jubilationHorizontalBar2 = _interopRequireDefault(_jubilationHorizontalBar);
 
-	var _jubilationVerticalBar = __webpack_require__(59);
+	var _jubilationVerticalBar = __webpack_require__(57);
 
 	var _jubilationVerticalBar2 = _interopRequireDefault(_jubilationVerticalBar);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _jubilationAxis = __webpack_require__(60);
+	var _jubilationAxis = __webpack_require__(58);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -27484,7 +27362,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = BarPlotExample;
 
 /***/ },
-/* 202 */
+/* 206 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -27499,19 +27377,19 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _jubilationChart = __webpack_require__(35);
+	var _jubilationChart = __webpack_require__(33);
 
 	var _jubilationChart2 = _interopRequireDefault(_jubilationChart);
 
-	var _jubilationScatter = __webpack_require__(53);
+	var _jubilationScatter = __webpack_require__(51);
 
 	var _jubilationScatter2 = _interopRequireDefault(_jubilationScatter);
 
-	var _jubilationTheme = __webpack_require__(39);
+	var _jubilationTheme = __webpack_require__(37);
 
 	var _jubilationTheme2 = _interopRequireDefault(_jubilationTheme);
 
-	var _jubilationAxis = __webpack_require__(60);
+	var _jubilationAxis = __webpack_require__(58);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -27734,6 +27612,158 @@ return /******/ (function(modules) { // webpackBootstrap
 	}(_react.Component);
 
 	exports.default = ScatterPlotExample;
+
+/***/ },
+/* 207 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _react = __webpack_require__(2);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	var ThemeForm = function ThemeForm(_ref) {
+	  var theme = _ref.theme,
+	      updateColors = _ref.updateColors,
+	      updateLabelStyle = _ref.updateLabelStyle,
+	      updateMargin = _ref.updateMargin,
+	      updateTheme = _ref.updateTheme;
+	  var axisColor = theme.axisColor,
+	      colors = theme.colors,
+	      _theme$labelStyle = theme.labelStyle,
+	      fill = _theme$labelStyle.fill,
+	      fontFamily = _theme$labelStyle.fontFamily,
+	      fontSize = _theme$labelStyle.fontSize,
+	      stroke = _theme$labelStyle.stroke,
+	      _theme$margin = theme.margin,
+	      left = _theme$margin.left,
+	      top = _theme$margin.top,
+	      right = _theme$margin.right,
+	      bottom = _theme$margin.bottom,
+	      name = theme.name,
+	      scale = theme.scale;
+
+
+	  return _react2.default.createElement(
+	    "form",
+	    null,
+	    _react2.default.createElement(
+	      "label",
+	      { htmlFor: "axisColor", style: { border: "2px solid " + axisColor } },
+	      "Axis Color",
+	      _react2.default.createElement("input", { id: "axisColor", value: axisColor, onChange: function onChange(e) {
+	          return updateTheme(e, 'axisColor');
+	        } })
+	    ),
+	    _react2.default.createElement(
+	      "label",
+	      { htmlFor: "colors" },
+	      "Color Scheme",
+	      _react2.default.createElement("input", { id: "colors", value: colors, onChange: function onChange(e) {
+	          return updateTheme(e, 'colors');
+	        } })
+	    ),
+	    _react2.default.createElement(
+	      "fieldset",
+	      { style: { border: "none" } },
+	      "Label Style",
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "fill" },
+	        "Label Fill",
+	        _react2.default.createElement("input", { id: "fill", value: fill, onChange: function onChange(e) {
+	            return updateLabelStyle(e, 'fill');
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "fontFamily" },
+	        "Label fontFamily",
+	        _react2.default.createElement("input", { id: "fontFamily", value: fontFamily, onChange: function onChange(e) {
+	            return updateLabelStyle(e, 'fontFamily');
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "fontSize" },
+	        "Label fontSize",
+	        _react2.default.createElement("input", { id: "fontSize", type: "number", value: fontSize, onChange: function onChange(e) {
+	            return updateLabelStyle(e, 'fontSize');
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "stroke" },
+	        "Label stroke",
+	        _react2.default.createElement("input", { id: "stroke", value: stroke, onChange: function onChange(e) {
+	            return updateLabelStyle(e, 'stroke');
+	          } })
+	      )
+	    ),
+	    _react2.default.createElement(
+	      "fieldset",
+	      { style: { border: "none" } },
+	      "Margin",
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "Left" },
+	        "Left",
+	        _react2.default.createElement("input", { id: "Left", type: "number", value: left, onChange: function onChange(e) {
+	            return updateMargin(e, 'left');
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "Top" },
+	        "Top",
+	        _react2.default.createElement("input", { id: "Top", type: "number", value: top, onChange: function onChange(e) {
+	            return updateMargin(e, "top");
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "Right" },
+	        "Right",
+	        _react2.default.createElement("input", { id: "Right", type: "number", value: right, onChange: function onChange(e) {
+	            return updateMargin(e, "right");
+	          } })
+	      ),
+	      _react2.default.createElement(
+	        "label",
+	        { htmlFor: "Bottom" },
+	        "Bottom",
+	        _react2.default.createElement("input", { id: "Bottom", type: "number", value: bottom, onChange: function onChange(e) {
+	            return updateMargin(e, "bottom");
+	          } })
+	      )
+	    ),
+	    _react2.default.createElement(
+	      "label",
+	      { htmlFor: "name" },
+	      "Name",
+	      _react2.default.createElement("input", { id: "name", value: name, onChange: function onChange(e) {
+	          return updateTheme(e, 'name');
+	        } })
+	    ),
+	    _react2.default.createElement(
+	      "label",
+	      { htmlFor: "scale" },
+	      "Scale",
+	      _react2.default.createElement("input", { id: "scale", type: "number", value: scale, onChange: function onChange(e) {
+	          return updateTheme(e, 'scale');
+	        } })
+	    )
+	  );
+	};
+
+	exports.default = ThemeForm;
 
 /***/ }
 /******/ ])

--- a/src/examples/examples.jsx
+++ b/src/examples/examples.jsx
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import AxisExample from './axis';
+import BarPlotExample from './barplot';
+import ScatterPlotExample from './scatterplot';
+import ThemeForm from './theme';
+import theme from '../jubilation-theme';
+
+
+class Examples extends Component {
+  constructor(props: Object) {
+    super(props);
+    this.updateTheme = this.updateTheme.bind(this);
+    this.updateLabelStyle = this.updateLabelStyle.bind(this);
+    this.updateMargin = this.updateMargin.bind(this);
+    
+    this.state = {
+      theme,
+    };
+  }
+
+  updateTheme(event: FormEvent, attr: string) {
+    const newAttrValue = event.target.value;
+    this.setState((oldState) => ({
+      theme: {
+        ...oldState.theme,
+        [attr]: newAttrValue
+      }
+    }))
+  }
+
+  updateLabelStyle(event: FormEvent, type: string) {
+    const newAttrValue = Number(event.target.value) || event.target.value;
+    this.setState((oldState) => ({
+      theme: {
+        ...oldState.theme,
+        labelStyle: {
+          ...oldState.theme.labelStyle,
+          [type]: newAttrValue
+        }
+      }
+    }))
+  }
+
+  updateMargin(event: FormEvent, type: string) {
+    const newAttrValue = Number(event.target.value) || event.target.value;
+    this.setState((oldState) => ({
+      theme: {
+        ...oldState.theme,
+        margin: {
+          ...oldState.theme.margin,
+          [type]: newAttrValue
+        }
+      }
+    }))
+  }
+
+  render() {
+    const handlers = {
+      updateLabelStyle: this.updateLabelStyle,
+      updateMargin: this.updateMargin,
+      updateTheme: this.updateTheme,
+    };
+    const { theme } = this.state;
+
+    return (
+      <div>
+        <ThemeForm theme={theme} {...handlers} />
+        <h1>Axis Examples</h1>
+        <AxisExample theme={theme} />
+        <h1>Bar Plot Examples</h1>
+        <BarPlotExample theme={theme} />
+        <h1>Scatter Plot Examples</h1>
+        <ScatterPlotExample theme={theme} />
+      </div>
+      );
+  }
+};
+
+export default Examples;

--- a/src/examples/index.jsx
+++ b/src/examples/index.jsx
@@ -1,16 +1,9 @@
 // @flow
 import React from 'react';
 import ReactDOM from 'react-dom';
-import AxisExample from './axis';
-import BarPlotExample from './barplot';
-import ScatterPlotExample from './scatterplot';
+import Examples from './examples';
 
 ReactDOM.render(
-  <div>
-    <h1>Axis Examples</h1>
-    <AxisExample />
-    <BarPlotExample />
-    <ScatterPlotExample />
-  </div>,
+  <Examples />,
   document.getElementById('root')
 );

--- a/src/examples/theme.jsx
+++ b/src/examples/theme.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+const ThemeForm = ({
+  theme,
+  updateColors,
+  updateLabelStyle,
+  updateMargin,
+  updateTheme,
+  }) => {
+
+  const {
+    axisColor,
+    colors,
+    labelStyle: {
+      fill,
+      fontFamily,
+      fontSize,
+      stroke,
+    },
+    margin: {
+      left,
+      top,
+      right,
+      bottom,
+    },
+    name,
+    scale,
+  } = theme;
+
+  return <form>
+    <label htmlFor="axisColor" style={{border: `2px solid ${axisColor}`}} >
+      Axis Color
+      <input id="axisColor" value={axisColor} onChange={e => updateTheme(e, 'axisColor')} />
+    </label>
+    <label htmlFor="colors">
+      Color Scheme
+      <input id="colors" value={colors} onChange={e => updateTheme(e, 'colors')} />
+    </label>
+    <fieldset style={{border: "none"}} >Label Style
+      <label htmlFor="fill">
+        Label Fill
+        <input id="fill" value={fill} onChange={e => updateLabelStyle(e, 'fill')} />
+      </label>
+      <label htmlFor="fontFamily">
+        Label fontFamily
+        <input id="fontFamily" value={fontFamily} onChange={e => updateLabelStyle(e, 'fontFamily')} />
+      </label>
+      <label htmlFor="fontSize">
+        Label fontSize
+        <input id="fontSize" type="number" value={fontSize} onChange={e => updateLabelStyle(e, 'fontSize')} />
+      </label>
+      <label htmlFor="stroke">
+        Label stroke
+        <input id="stroke" value={stroke} onChange={e => updateLabelStyle(e, 'stroke')} />
+      </label>
+    </fieldset>
+    <fieldset style={{border: "none"}}>Margin
+      <label htmlFor="Left">
+        Left
+        <input id="Left" type="number" value={left} onChange={e=> updateMargin(e, 'left')} />
+      </label>
+      <label htmlFor="Top">
+        Top
+        <input id="Top" type="number" value={top} onChange={e => updateMargin(e, "top")} />
+      </label>
+      <label htmlFor="Right">
+        Right
+        <input id="Right" type="number" value={right} onChange={e => updateMargin(e, "right")} />
+      </label>
+      <label htmlFor="Bottom">
+        Bottom
+        <input id="Bottom" type="number" value={bottom} onChange={e => updateMargin(e, "bottom")} />
+      </label>
+    </fieldset>
+    <label htmlFor="name">
+      Name
+      <input id="name" value={name} onChange={e => updateTheme(e, 'name')} />
+    </label>
+    <label htmlFor="scale">
+      Scale
+      <input id="scale" type="number" value={scale} onChange={e => updateTheme(e, 'scale')} />
+    </label>
+  </form>
+};
+
+export default ThemeForm


### PR DESCRIPTION
In order to see the impact changing the theme will have, this adds a form to
the examples page. This form sets the attributes for a theme and then that theme
is passed downward to all child examples, in order to show the impact it has.

Currently, this causes a serious performance hit during rapid changes to the
theme. That will need additional investigation. Additionally, the form has no
styling and is, thus, hideous.